### PR TITLE
feat(fb2d): Add rendering and a game loop

### DIFF
--- a/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/extensions.dart
+++ b/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/extensions.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_box2d/flutter_box2d.dart';
+
+extension B2Vec2Extensions on B2Vec2 {
+  Offset toOffSet() => Offset(x, y);
+}

--- a/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/game_loop.dart
+++ b/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/game_loop.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
+
+/// The game loop is just a [Ticker] that calls [callback] on each frame.
+/// The value [elapsed], the time since the last frame (in seconds), is calculated
+/// each tick and passed in to [callback].
+class GameLoop {
+  GameLoop({required this.onTick, bool startImmediately = true}) {
+    _ticker = Ticker(_tick);
+    if (startImmediately) start();
+  }
+
+  /// A function that is called every frame, with the elapsed time since last frame.
+  void Function(double elapsed) onTick;
+
+  /// A [ValueNotifier] that is updated every frame with the elapsed time since last frame.
+  final tickNotifier = ValueNotifier<double>(0);
+
+  /// Total time passed, up to the previous frame.
+  Duration _previous = Duration.zero;
+
+  /// A [Ticker] that calls [callback] on each tick.
+  late final Ticker _ticker;
+
+  /// Called by the [Ticker] on every frame.
+  void _tick(Duration current) {
+    var deltaDuration = current - _previous;
+    _previous = current;
+
+    final elapsed =
+        deltaDuration.inMicroseconds / Duration.microsecondsPerSecond;
+
+    onTick(elapsed);
+    tickNotifier.value = elapsed;
+  }
+
+  void start() {
+    if (!_ticker.isActive) {
+      _ticker.start();
+    }
+  }
+
+  void stop() {
+    _ticker.stop();
+    _previous = Duration.zero;
+  }
+
+  /// See docs for [Ticker.dispose]
+  void dispose() {
+    _ticker.dispose();
+  }
+}

--- a/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/game_widget.dart
+++ b/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/game_widget.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import 'game_loop.dart';
+import 'game_world.dart';
+import 'game_world_painter.dart';
+
+class GameWidget extends StatefulWidget {
+  const GameWidget(GameWorld gameWorld, {Key? key})
+      : _gameWorld = gameWorld,
+        super(key: key);
+
+  final GameWorld _gameWorld;
+
+  @override
+  State<GameWidget> createState() => _GameWidgetState();
+}
+
+class _GameWidgetState extends State<GameWidget>
+    with SingleTickerProviderStateMixin {
+  late final GameLoop _gameLoop;
+
+  @override
+  void initState() {
+    super.initState();
+    _gameLoop = GameLoop(onTick: update);
+  }
+
+  void update(double dt) {
+    if (mounted) widget._gameWorld.update(dt);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, constraints) {
+      return CustomPaint(
+          painter: GameWorldPainter(widget._gameWorld,
+              notifiyRepaint: _gameLoop.tickNotifier));
+    });
+  }
+
+  @override
+  void dispose() {
+    _gameLoop.dispose();
+    super.dispose();
+  }
+}

--- a/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/game_world.dart
+++ b/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/game_world.dart
@@ -1,0 +1,34 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:flutter_box2d/flutter_box2d.dart';
+import 'package:flutter_box2d_example/square_object.dart';
+
+const maxTimeStepMs = 1 / 60;
+const velocityIterations = 1;
+const positionIterations = 1;
+
+void step(double deltaMs) {}
+
+class GameWorld {
+  GameWorld() {
+    var gravity = B2Vec2(0, 10);
+    _b2World = B2World(gravity);
+
+    _square = SquareObject(_b2World);
+  }
+
+  late final B2World _b2World;
+  late final SquareObject _square;
+
+  /// Advances the world's physics by the requested number of seconds.
+  /// Calculate no more than a 60th of a second during one world.Step() call
+  void update(double dt) {
+    _b2World.step(
+        min(dt, maxTimeStepMs), velocityIterations, positionIterations);
+  }
+
+  void paintOn(Canvas canvas) {
+    _square.paintOn(canvas);
+  }
+}

--- a/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/game_world_painter.dart
+++ b/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/game_world_painter.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+import 'game_world.dart';
+
+class GameWorldPainter extends CustomPainter {
+  GameWorldPainter(GameWorld gameWorld,
+      {required ChangeNotifier notifiyRepaint})
+      : _gameWorld = gameWorld,
+        super(repaint: notifiyRepaint);
+
+  final GameWorld _gameWorld;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    _gameWorld.paintOn(canvas);
+  }
+
+  @override
+  bool shouldRepaint(GameWorldPainter oldDelegate) => false;
+}

--- a/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/main.dart
+++ b/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/main.dart
@@ -1,61 +1,31 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_box2d/flutter_box2d.dart';
+import 'package:flutter_box2d_example/game_widget.dart';
+import 'package:flutter_box2d_example/game_world.dart';
 
 void main() {
-  WidgetsFlutterBinding.ensureInitialized();
-  var gravity = B2Vec2(0, -10);
-  print(gravity.length);
-  var world = B2World(gravity);
+  // WidgetsFlutterBinding.ensureInitialized();
 
-  var sideLengthMetres = 1;
-  var square = B2PolygonShape();
-  square.setAsBox(sideLengthMetres / 2, sideLengthMetres / 2);
-  print(square.getType());
+  var gameWorld = GameWorld();
 
-  var zero = B2Vec2(0, 0);
-
-  var bd = B2BodyDef();
-  bd.setType(b2BodyType.b2_dynamicBody);
-  bd.setPosition(zero);
-
-  var body = world.createBody(bd);
-  body.createFixture(square, 1);
-  body.setTransform(zero, 0);
-  body.setLinearVelocity(zero);
-  body.setAwake(true);
-  body.setEnabled(true);
-
-  world.step(0.1, 1, 1);
-  print('p: ${body.getPosition().x}, ${body.getPosition().y}');
-  print('v: ${body.getLinearVelocity().x}, ${body.getLinearVelocity().y}');
-  world.step(0.1, 1, 1);
-  print('p: ${body.getPosition().x}, ${body.getPosition().y}');
-  print('v: ${body.getLinearVelocity().x}, ${body.getLinearVelocity().y}');
-
-  runApp(const MyApp());
+  runApp(MyApp(gameWorld));
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp(this.gameWorld, {Key? key}) : super(key: key);
+
+  final GameWorld gameWorld;
 
   @override
   State<MyApp> createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
-  final String _platformVersion = 'Unknown';
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Plugin example app'),
-        ),
-        body: Center(
-          child: Text('Running on: $_platformVersion\n'),
-        ),
-      ),
+          appBar: AppBar(title: const Text('Box2Plugin Example')),
+          body: GameWidget(widget.gameWorld)),
     );
   }
 }

--- a/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/square_object.dart
+++ b/packages/flutter-plugins/flutter_box2d/flutter_box2d/example/lib/square_object.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_box2d/flutter_box2d.dart';
+
+import 'extensions.dart';
+
+class SquareObject {
+  SquareObject(B2World world, {int sideLengthMetres = 1})
+      : _sideLengthMetres = sideLengthMetres,
+        _sideLengthPixels = sideLengthMetres * 100 {
+    _paint = Paint()..color = Colors.red;
+
+    _shape.setAsBox(_sideLengthMetres / 2, _sideLengthMetres / 2);
+
+    var zero = B2Vec2(0, 0);
+
+    var bd = B2BodyDef();
+    bd.setType(b2BodyType.b2_dynamicBody);
+    bd.setPosition(zero);
+
+    _body = world.createBody(bd);
+    _body.createFixture(_shape, 1);
+    _body.setTransform(zero, 0);
+    _body.setLinearVelocity(zero);
+    _body.setAwake(true);
+    _body.setEnabled(true);
+  }
+
+  late final Paint _paint;
+  late final B2Body _body;
+  final int _sideLengthMetres;
+  final double _sideLengthPixels;
+  final _shape = B2PolygonShape();
+
+  B2Body get body => _body;
+  B2PolygonShape get shape => _shape;
+
+  void paintOn(Canvas canvas) {
+    canvas.drawRect(
+        Rect.fromCenter(
+            center: _body.getPosition().toOffSet(),
+            width: _sideLengthPixels,
+            height: _sideLengthPixels),
+        _paint);
+  }
+
+  /// Prints out the vertical position of our falling square
+  void whereIsOurSquare() {
+    final v = _body.getLinearVelocity();
+    print("Square's velocity is: ${v.x}, ${v.y}");
+    final p = _body.getPosition();
+    print("Square's position is: ${p.x}, ${p.y}");
+  }
+}


### PR DESCRIPTION
I added a GameWidget that holds a GameLoop and CustomPainter - the
CustomPainter repaints on each tick so we can render the game world.

A GameWorldPainter takes a GameWorld object and paints everything in the
world, which means our GameWidget has everything needed render the game.

I used the Update Method pattern, so the GameWorld and SquareObject have
update(dt) and a paintOn(canvas) functions.