### PR TITLE
feat(apn): add Notion Client

### DIFF
--- a/packages/dart/api-clients/notion/.gitignore
+++ b/packages/dart/api-clients/notion/.gitignore
@@ -1,0 +1,13 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock
+
+# Used for e2e tests during prototyping
+example/credentials.dart

--- a/packages/dart/api-clients/notion/CHANGELOG.md
+++ b/packages/dart/api-clients/notion/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.1
+
+- Initial version.

--- a/packages/dart/api-clients/notion/README.md
+++ b/packages/dart/api-clients/notion/README.md
@@ -1,0 +1,43 @@
+# notion_api_client
+
+*A Dart client for the Notion API.*
+
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/packages/dart/api-clients/notion/analysis_options.yaml
+++ b/packages/dart/api-clients/notion/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/packages/dart/api-clients/notion/example/notion_api_client_example.dart
+++ b/packages/dart/api-clients/notion/example/notion_api_client_example.dart
@@ -1,0 +1,12 @@
+import 'package:notion_api_client/notion_api_client.dart';
+
+import 'credentials.dart';
+
+void main() async {
+  var client = NotionClient(token: token);
+
+  var json = await client.retrievePageProperties(
+      id: 'e93dda7fa5ed4e28ba27e857cd1f6757');
+
+  print(json);
+}

--- a/packages/dart/api-clients/notion/lib/notion_api_client.dart
+++ b/packages/dart/api-clients/notion/lib/notion_api_client.dart
@@ -1,0 +1,4 @@
+/// A Dart client for the Notion API.
+library notion_api_client;
+
+export 'src/notion_api_client_base.dart';

--- a/packages/dart/api-clients/notion/lib/src/notion_api_client_base.dart
+++ b/packages/dart/api-clients/notion/lib/src/notion_api_client_base.dart
@@ -1,0 +1,28 @@
+import 'package:api_client_utils/api_client_utils.dart';
+import 'package:http/http.dart' as http;
+
+class NotionClient {
+  static const _host = 'api.notion.com';
+  static const _basePath = 'v1';
+  final http.Client _client;
+  late final ApiRequester _requester;
+
+  NotionClient({http.Client? client, required String token})
+      : _client = client ?? http.Client() {
+    _requester = ApiRequester(_client, _host, _basePath,
+        {'Authorization': 'Bearer $token', 'Notion-Version': '2022-02-22'});
+  }
+
+  /// "GET" or "POST", "HEAD", "PUT", or "DELETE"
+  Future<Object?> retrievePageProperties({required String id}) async {
+    var json = await _requester.request('GET', 'pages/$id');
+    return json;
+  }
+
+  Future<Object?> retrievePageContent({required String id}) async {
+    var json = await _requester.request('GET', 'pages/$id');
+    return json;
+  }
+
+  void close() => _client.close();
+}

--- a/packages/dart/api-clients/notion/pubspec.yaml
+++ b/packages/dart/api-clients/notion/pubspec.yaml
@@ -1,0 +1,16 @@
+name: notion_api_client
+description: A Dart client for the Notion API.
+version: 0.0.1
+publish_to: none
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  http: ^0.13.4
+  api_client_utils:
+    path: ../api_client_utils
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.16.0

--- a/packages/dart/api-clients/notion/test/notion_api_client_test.dart
+++ b/packages/dart/api-clients/notion/test/notion_api_client_test.dart
@@ -1,0 +1,29 @@
+import 'dart:async';
+
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:notion_api_client/notion_api_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Smoke tests >', () {
+    setUp(() {
+      // Additional setup goes here.
+    });
+
+    test('NotionClient takes a http.Client and uses it to call an endpoint',
+        () {
+      final bodyController = StreamController<List<int>>();
+      bodyController.close();
+      var response = StreamedResponse(bodyController.stream, 200,
+          headers: {'content-type': 'application/json'});
+      var mockClient =
+          MockClient.streaming((req, stream) => Future.value(response));
+      var notion = NotionClient(client: mockClient, token: 'token');
+      notion.retrievePageProperties(id: 'e93dda7fa5ed4e28ba27e857cd1f6757');
+      notion.close();
+
+      expect(true, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
This is jsut a minimal starting point that uses the APIRequester 
from api_client_utils.

The NotionClient requires a user supplied bearer token to be 
passed in order to make authenticated requests.