### PR TITLE
refactor(rfr): update AvatarMenuButton options member to non-nullable

### DIFF
--- a/packages/flutter/apps/adventuring/adventure_maker/lib/home/pages/home_page.dart
+++ b/packages/flutter/apps/adventuring/adventure_maker/lib/home/pages/home_page.dart
@@ -46,7 +46,14 @@ class _HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        actions: const [AvatarMenuButton<AppState>()],
+        actions: const [
+          AvatarMenuButton<AppState>(
+            options: {
+              MenuOptionPreset.accountDetails,
+              MenuOptionPreset.signOut
+            },
+          )
+        ],
         bottom: PreferredSize(
             preferredSize: const Size.fromHeight(50),
             child: Row(

--- a/packages/flutter/apps/adventuring/tech_world/lib/home/pages/home_page.dart
+++ b/packages/flutter/apps/adventuring/tech_world/lib/home/pages/home_page.dart
@@ -32,7 +32,12 @@ class HomePage extends StatelessWidget {
                 const StartChallengeButton()
               else
                 const DismissChallengeButton(),
-              const AvatarMenuButton<AppState>(),
+              const AvatarMenuButton<AppState>(
+                options: {
+                  MenuOptionPreset.accountDetails,
+                  MenuOptionPreset.signOut
+                },
+              ),
             ],
           ),
           body: Stack(

--- a/packages/flutter/apps/experiments/domain_visualiser/lib/widgets/drawing_page.dart
+++ b/packages/flutter/apps/experiments/domain_visualiser/lib/widgets/drawing_page.dart
@@ -20,7 +20,14 @@ class DrawingPage extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: const [
-              Material(child: AvatarMenuButton<AppState>()),
+              Material(
+                child: AvatarMenuButton<AppState>(
+                  options: {
+                    MenuOptionPreset.accountDetails,
+                    MenuOptionPreset.signOut
+                  },
+                ),
+              ),
             ],
           ),
         ),

--- a/packages/flutter/apps/utils/redfire/lib/src/shared/widgets/buttons/menu_button/avatar_menu_button.dart
+++ b/packages/flutter/apps/utils/redfire/lib/src/shared/widgets/buttons/menu_button/avatar_menu_button.dart
@@ -8,8 +8,8 @@ import 'composite_menu_button.dart';
 import 'menu_option.dart';
 
 class AvatarMenuButton<T extends RedFireState> extends StatefulWidget {
-  const AvatarMenuButton({Set<MenuOption>? options, Key? key})
-      : _options = options ?? const {},
+  const AvatarMenuButton({required Set<MenuOption> options, Key? key})
+      : _options = options,
         super(key: key);
 
   final Set<MenuOption> _options;


### PR DESCRIPTION
This fixes the issue of being able to create an AvatarMenuButton with
no options which makes no sense in the current setup where none are
automatically added.

I also fixed the few places where an AvatarMenuButton was being
created with no options.