### PR TITLE
Change dependency on json_utils to git

### DIFF
--- a/packages/dart/api-clients/firestore/pubspec.yaml
+++ b/packages/dart/api-clients/firestore/pubspec.yaml
@@ -10,7 +10,10 @@ dependencies:
   googleapis: ^8.0.0
   googleapis_auth: ^1.3.0
   json_utils:
-    path: ../../utils/json_utils
+    git:
+      url: https://github.com/enspyrco/monorepo.git
+      path: packages/dart/utils/json_utils
+    # path: ../../utils/json_utils
 
 dev_dependencies:
   lints: ^1.0.0

--- a/packages/dart/api-clients/git-hub/pubspec.yaml
+++ b/packages/dart/api-clients/git-hub/pubspec.yaml
@@ -11,7 +11,10 @@ dependencies:
   googleapis_auth: ^1.3.0
   http: ^0.13.4
   json_utils:
-    path: ../../utils/json_utils
+    git:
+      url: https://github.com/enspyrco/monorepo.git
+      path: packages/dart/utils/json_utils
+    # path: ../../utils/json_utils
   
 dev_dependencies:
   lints: ^1.0.0


### PR DESCRIPTION
I made this change so we can use packages that depend on json_utils via
a git dependency.