### PR TITLE
chore(gla): update path deps to git deps

### DIFF
--- a/packages/dart/api-clients/firestore/pubspec.yaml
+++ b/packages/dart/api-clients/firestore/pubspec.yaml
@@ -10,11 +10,20 @@ dependencies:
   googleapis: ^9.1.0
   googleapis_auth: ^1.3.1
   firestore_service_interface:
-    path: ../../../interfaces/firestore_service_interface
+    git:
+      url: https://github.com/enspyrco/monorepo.git
+      path: packages/interfaces/firestore_service_interface
+    # path: ../../../interfaces/firestore_service_interface
   googleapis_utils:
-    path: ../../utils/googleapis_utils
+    git:
+      url: https://github.com/enspyrco/monorepo.git
+      path: packages/dart/utils/googleapis_utils
+    # path: ../../utils/googleapis_utils
   json_utils:
-    path: ../../utils/json_utils
+    git:
+      url: https://github.com/enspyrco/monorepo.git
+      path: packages/dart/utils/json_utils
+    # path: ../../utils/json_utils
 
 dev_dependencies:
   lints: ^1.0.0

--- a/packages/dart/servers/gather_link_account_shelf/pubspec.yaml
+++ b/packages/dart/servers/gather_link_account_shelf/pubspec.yaml
@@ -12,9 +12,15 @@ dependencies:
   shelf_router: ^1.0.0
   googleapis_auth: ^1.3.1
   firestore_api_client:
-    path: ../../api-clients/firestore
+    git:
+      url: https://github.com/enspyrco/monorepo.git
+      path: packages/dart/api-clients/firestore
+    # path: ../../api-clients/firestore
   json_utils:
-    path: ../../utils/json_utils
+    git:
+      url: https://github.com/enspyrco/monorepo.git
+      path: packages/dart/utils/json_utils
+    # path: ../../utils/json_utils
 
 dev_dependencies:
   http: ^0.13.0

--- a/packages/dart/servers/gather_link_account_shelf/test/dev.rest
+++ b/packages/dart/servers/gather_link_account_shelf/test/dev.rest
@@ -1,1 +1,1 @@
-GET http://localhost:8080/gather/?playerId=1&nonce=24562 HTTP/1.1
+GET http://localhost:8080/gather/?playerId=1&nonce=abcd HTTP/1.1

--- a/packages/dart/utils/googleapis_utils/pubspec.yaml
+++ b/packages/dart/utils/googleapis_utils/pubspec.yaml
@@ -9,7 +9,10 @@ environment:
 dependencies:
   googleapis: ^9.1.0
   json_utils:
-    path: ../json_utils
+    git:
+      url: https://github.com/enspyrco/monorepo.git
+      path: packages/dart/utils/json_utils
+    # path: ../json_utils
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/interfaces/firestore_service_interface/pubspec.yaml
+++ b/packages/interfaces/firestore_service_interface/pubspec.yaml
@@ -8,7 +8,10 @@ environment:
 
 dependencies:
   json_utils:
-    path: ../../dart/utils/json_utils
+    git:
+      url: https://github.com/enspyrco/monorepo.git
+      path: packages/dart/utils/json_utils
+    # path: ../../dart/utils/json_utils
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
When we build the app during Docker's build having path deps causes
errors. There are other solutions but this is the easiest for now.