### PR TITLE
new(rdw): Add redux_widgets package

### DIFF
--- a/packages/flutter/utils/redux_widgets/.gitignore
+++ b/packages/flutter/utils/redux_widgets/.gitignore
@@ -1,0 +1,30 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.packages
+build/

--- a/packages/flutter/utils/redux_widgets/.metadata
+++ b/packages/flutter/utils/redux_widgets/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: f1875d570e39de09040c8f79aa13cc56baab8db1
+  channel: stable
+
+project_type: package

--- a/packages/flutter/utils/redux_widgets/CHANGELOG.md
+++ b/packages/flutter/utils/redux_widgets/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.1
+
+* TODO: Describe initial release.

--- a/packages/flutter/utils/redux_widgets/LICENSE
+++ b/packages/flutter/utils/redux_widgets/LICENSE
@@ -1,0 +1,1 @@
+TODO: Add your license here.

--- a/packages/flutter/utils/redux_widgets/README.md
+++ b/packages/flutter/utils/redux_widgets/README.md
@@ -1,0 +1,27 @@
+# redux_widgets
+
+Widgets for interacting with a redux store from enspyr_redux.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/packages/flutter/utils/redux_widgets/analysis_options.yaml
+++ b/packages/flutter/utils/redux_widgets/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/packages/flutter/utils/redux_widgets/lib/errors/store_provider_not_found_error.dart
+++ b/packages/flutter/utils/redux_widgets/lib/errors/store_provider_not_found_error.dart
@@ -1,0 +1,15 @@
+import 'package:enspyr_redux/redux.dart';
+
+class StoreProviderNotFoundError<S extends ReduxState> extends Error {
+  StoreProviderNotFoundError();
+
+  @override
+  String toString() {
+    return '''Error: No StoreProvider<$S> found. Try:
+          
+  * Put StoreProvider<$S> above MaterialApp
+  * Provide full type information to Store<$S>, StoreProvider<$S>
+    and StoreConnector<$S, VM>
+''';
+  }
+}

--- a/packages/flutter/utils/redux_widgets/lib/exceptions/transform_failure_exception.dart
+++ b/packages/flutter/utils/redux_widgets/lib/exceptions/transform_failure_exception.dart
@@ -1,0 +1,20 @@
+/// Thrown when the StoreConnector encounters a problem while
+/// running the [StoreConnector.transform] function.
+class TransformFailureException implements Exception {
+  final Object exception;
+  final StackTrace trace;
+  TransformFailureException(this.exception, this.trace);
+
+  @override
+  String toString() {
+    return '''Transform Function Error: If the transform function passed
+to the StoreConnector throws when applied, we wrap what was thrown in a
+TransformFailureException. Below is what was originally thrown:
+
+$exception
+    
+$trace
+
+''';
+  }
+}

--- a/packages/flutter/utils/redux_widgets/lib/redux_widget.dart
+++ b/packages/flutter/utils/redux_widgets/lib/redux_widget.dart
@@ -1,0 +1,184 @@
+library redux_widgets;
+
+import 'dart:async';
+
+import 'package:enspyr_redux/redux.dart';
+import 'package:flutter/widgets.dart';
+
+import 'errors/store_provider_not_found_error.dart';
+import 'exceptions/transform_failure_exception.dart';
+
+class StoreProvider<S extends ReduxState> extends InheritedWidget {
+  final ReduxStore<S> _store;
+
+  const StoreProvider({
+    Key? key,
+    required ReduxStore<S> store,
+    required Widget child,
+  })  : _store = store,
+        super(key: key, child: child);
+
+  static ReduxStore<S> of<S extends ReduxState>(BuildContext context,
+      {bool listen = true}) {
+    final provider = (listen
+        ? context.dependOnInheritedWidgetOfExactType<StoreProvider<S>>()
+        : context
+            .getElementForInheritedWidgetOfExactType<StoreProvider<S>>()
+            ?.widget) as StoreProvider<S>?;
+
+    if (provider == null) throw StoreProviderNotFoundError<S>();
+
+    return provider._store;
+  }
+
+  @override
+  bool updateShouldNotify(StoreProvider<S> oldWidget) =>
+      _store != oldWidget._store;
+}
+
+class StoreConnector<S extends ReduxState, VM> extends StatelessWidget {
+  final Widget Function(BuildContext context, VM vm) builder;
+  final VM Function(S state) transformer;
+  final void Function(ReduxStore<S> store)? onInit;
+  final void Function(ReduxStore<S> store)? onDispose;
+
+  const StoreConnector({
+    Key? key,
+    required this.builder,
+    required this.transformer,
+    this.onInit,
+    this.onDispose,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return _StoreConnectorChild<S, VM>(
+      store: StoreProvider.of<S>(context),
+      builder: builder,
+      transformer: transformer,
+      onInit: onInit,
+      onDispose: onDispose,
+    );
+  }
+}
+
+class _StoreConnectorChild<S extends ReduxState, VM> extends StatefulWidget {
+  final ReduxStore<S> store;
+  final Widget Function(BuildContext context, VM vm) builder;
+  final VM Function(S state) transformer;
+  final void Function(ReduxStore<S> store)? onInit;
+  final void Function(ReduxStore<S> store)? onDispose;
+
+  const _StoreConnectorChild({
+    Key? key,
+    required this.store,
+    required this.transformer,
+    required this.builder,
+    this.onInit,
+    this.onDispose,
+  }) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() {
+    return _StoreConnectorChildState<S, VM>();
+  }
+}
+
+class _StoreConnectorChildState<S extends ReduxState, VM>
+    extends State<_StoreConnectorChild<S, VM>> {
+  late Stream<VM> _stream;
+  VM? _latestValue;
+  Object? _latestError;
+
+  // `_latestValue!` would throw _CastError if `VM` is nullable,
+  // therefore `_latestValue as VM` is used.
+  // https://dart.dev/null-safety/understanding-null-safety#nullability-and-generics
+  VM get _requireLatestValue => _latestValue as VM;
+
+  @override
+  void initState() {
+    super.initState();
+
+    widget.onInit?.call(widget.store);
+
+    _computeLatestValue();
+    _createStream();
+  }
+
+  @override
+  void dispose() {
+    widget.onDispose?.call(widget.store);
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(_StoreConnectorChild<S, VM> oldWidget) {
+    _computeLatestValue();
+
+    if (widget.store != oldWidget.store) {
+      _createStream();
+    }
+
+    super.didUpdateWidget(oldWidget);
+  }
+
+  void _computeLatestValue() {
+    try {
+      _latestError = null;
+      _latestValue = widget.transformer(widget.store.state);
+    } catch (e, s) {
+      _latestValue = null;
+      _latestError = TransformFailureException(e, s);
+    }
+  }
+
+  void _createStream() {
+    _stream = widget.store.stateChanges
+        .map((_) => widget.transformer(widget.store.state))
+        .transform(StreamTransformer.fromHandlers(
+            handleError: _handleTransformFailure))
+        .where((vm) => vm != _latestValue)
+        .transform(StreamTransformer.fromHandlers(handleData: _handleChange))
+        .transform(StreamTransformer.fromHandlers(handleError: _handleError));
+  }
+
+  void _handleTransformFailure(
+    Object error,
+    StackTrace stackTrace,
+    EventSink<VM> sink,
+  ) {
+    sink.addError(TransformFailureException(error, stackTrace), stackTrace);
+  }
+
+  // After each VM is emitted from the Stream, we update the
+  // latestValue. Important: This must be done after all other optional
+  // transformations, such as ignoreChange.
+  void _handleChange(VM vm, EventSink<VM> sink) {
+    _latestError = null;
+    _latestValue = vm;
+    sink.add(vm);
+  }
+
+  // Handle any errors from transformer/onWillChange/onDidChange
+  void _handleError(
+    Object error,
+    StackTrace stackTrace,
+    EventSink<VM> sink,
+  ) {
+    _latestValue = null;
+    _latestError = error;
+    sink.addError(error, stackTrace);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<VM>(
+      stream: _stream,
+      builder: (context, snapshot) {
+        if (_latestError != null) throw _latestError!;
+
+        return widget.builder(context, _requireLatestValue);
+      },
+    );
+  }
+}

--- a/packages/flutter/utils/redux_widgets/pubspec.yaml
+++ b/packages/flutter/utils/redux_widgets/pubspec.yaml
@@ -1,0 +1,22 @@
+name: redux_widgets
+description: Widgets for interacting with a redux store from enspyr_redux.
+version: 0.0.1
+publish_to: none
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=1.17.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  
+  enspyr_redux:
+    git:
+      url: https://github.com/enspyrco/monorepo.git
+      path: packages/dart/utils/redux
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0

--- a/packages/flutter/utils/redux_widgets/pubspec_overrides.yaml
+++ b/packages/flutter/utils/redux_widgets/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  enspyr_redux:
+    path: ../../../dart/utils/redux

--- a/packages/flutter/utils/redux_widgets/test/redux_widget_test.dart
+++ b/packages/flutter/utils/redux_widgets/test/redux_widget_test.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('', () {
+    expect(true, true);
+  });
+}


### PR DESCRIPTION
I added a new flutter package called redux_widgets - it has widgets for interacting with a redux store:
- put the store into the widget tree
- retrieve the store via InheritedWidget
- listen to changes in app state and rebuild the child widget tree on changes