### PR TITLE
new(fai): add firebase_auth_service_interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Three letter acronyms used in commit messages:
 - ccv = coding-challenge-verifier
 - dvr = domain_visualiser
 - flr = flireator
+- fai = firebase_auth_service_interface
 - fsg = firestore_service_googleapis
 - fsi = firestore_service_interface
 - fsf = firestore_service_flutterfire

--- a/cloud-mono/packages/process-articles-in-emails/pubspec.lock
+++ b/cloud-mono/packages/process-articles-in-emails/pubspec.lock
@@ -88,9 +88,9 @@ packages:
   firestore_service_interface:
     dependency: transitive
     description:
-      path: "packages/interfaces/firestore_service_interface"
+      path: "packages/dart/interfaces/firestore_service_interface"
       ref: HEAD
-      resolved-ref: "631900d98cc92c0355979b17242ecb23a9b162d4"
+      resolved-ref: "31fcab648fd517df655810250f85d8aa318414c5"
       url: "https://github.com/enspyrco/monorepo.git"
     source: git
     version: "0.0.1"

--- a/packages/dart/interfaces/firebase_auth_service_interface/.gitignore
+++ b/packages/dart/interfaces/firebase_auth_service_interface/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/dart/interfaces/firebase_auth_service_interface/CHANGELOG.md
+++ b/packages/dart/interfaces/firebase_auth_service_interface/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.1
+
+- Initial version.

--- a/packages/dart/interfaces/firebase_auth_service_interface/README.md
+++ b/packages/dart/interfaces/firebase_auth_service_interface/README.md
@@ -1,0 +1,28 @@
+# firebase_auth_service_interface
+
+*An interface for a firebase auth service allowing different implementations for
+Flutter apps (FlutterFire) and Dart servers (googleapis.dart).*
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/packages/dart/interfaces/firebase_auth_service_interface/analysis_options.yaml
+++ b/packages/dart/interfaces/firebase_auth_service_interface/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/packages/dart/interfaces/firebase_auth_service_interface/example/firebase_auth_service_interface_example.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/example/firebase_auth_service_interface_example.dart
@@ -1,0 +1,3 @@
+void main() {
+  print('awesome: isAwesome');
+}

--- a/packages/dart/interfaces/firebase_auth_service_interface/lib/firebase_auth_service_interface.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/lib/firebase_auth_service_interface.dart
@@ -1,0 +1,3 @@
+library firebase_auth_service_interface;
+
+export 'src/firebase_auth_service.dart';

--- a/packages/dart/interfaces/firebase_auth_service_interface/lib/src/enums/provider_enum.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/lib/src/enums/provider_enum.dart
@@ -1,0 +1,6 @@
+enum ProviderEnum {
+  apple,
+  google,
+  email,
+  github,
+}

--- a/packages/dart/interfaces/firebase_auth_service_interface/lib/src/firebase_auth_service.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/lib/src/firebase_auth_service.dart
@@ -1,0 +1,35 @@
+import 'enums/provider_enum.dart';
+import 'models/auth_user_data.dart';
+import 'models/id_token_result.dart';
+import 'models/provider_credential.dart';
+import 'models/user_credential.dart';
+
+abstract class FirebaseAuthService {
+  // Functions to get user details, or throw if there is no current user.
+  Future<String> getCurrentIdToken();
+  String getCurrentUserId();
+
+  Stream<AuthUserData> get streamOfAuthUserData;
+
+  Future<AuthUserData> signInAnonymously();
+
+  Future<IdTokenResult>? getIdTokenResult();
+
+  Future<Set<ProviderEnum>> retrieveProvidersFor(String email);
+
+  Future<UserCredential> signUpWithEmailAndPassword(
+      String email, String password);
+
+  Future<UserCredential> signInWithEmailAndPassword(
+      String email, String password);
+
+  Future<AuthUserData> signIn(
+      {required ProviderEnum provider, required ProviderCredential credential});
+
+  Future<AuthUserData> link(
+      {required ProviderEnum provider, required ProviderCredential credential});
+
+  /// If a provider is passed, the user will be signed out of the provider then
+  /// out of FirebaseAuth.
+  Future<void> signOut({ProviderEnum? provider});
+}

--- a/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/additional_user_info.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/additional_user_info.dart
@@ -1,0 +1,35 @@
+/// Copied from: firebase_auth_platform_interface-6.5.2/lib/src/additional_user_info.dart
+/// TODO: Check if this works for the REST client too
+
+/// A structure containing additional user information from a federated identity
+/// provider.
+class AdditionalUserInfo {
+  AdditionalUserInfo({
+    required this.isNewUser,
+    this.profile,
+    this.providerId,
+    this.username,
+  });
+
+  /// Whether the user account has been recently created.
+  final bool isNewUser;
+
+  /// A [Map] containing additional profile information from the identity
+  /// provider.
+  final Map<String, dynamic>? profile;
+
+  /// The federated identity provider ID.
+  final String? providerId;
+
+  /// The username given from the federated identity provider.
+  final String? username;
+
+  @override
+  String toString() {
+    return '$AdditionalUserInfo('
+        'isNewUser: $isNewUser, '
+        'profile: $profile, '
+        'providerId: $providerId, '
+        'username: $username)';
+  }
+}

--- a/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/auth_credential.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/auth_credential.dart
@@ -1,0 +1,38 @@
+/// Copided from firebase_auth_platform_interface-6.5.2/lib/srcauth_credential.dart
+/// TODO: Check if this works for the REST client too
+
+/// Interface that represents the credentials returned by an auth provider.
+/// Implementations specify the details about each auth provider's credential
+/// requirements.
+class AuthCredential {
+  const AuthCredential({
+    required this.providerId,
+    required this.signInMethod,
+    this.token,
+  });
+
+  /// The authentication provider ID for the credential. For example,
+  /// 'facebook.com', or 'google.com'.
+  final String providerId;
+
+  /// The authentication sign in method for the credential. For example,
+  /// 'password', or 'emailLink'. This corresponds to the sign-in method
+  /// identifier returned in [fetchSignInMethodsForEmail].
+  final String signInMethod;
+
+  /// A token used to identify the AuthCredential on native platforms.
+  final int? token;
+
+  /// Returns the current instance as a serialized [Map].
+  Map<String, dynamic> asMap() {
+    return <String, dynamic>{
+      'providerId': providerId,
+      'signInMethod': signInMethod,
+      'token': token,
+    };
+  }
+
+  @override
+  String toString() =>
+      'AuthCredential(providerId: $providerId, signInMethod: $signInMethod, token: $token)';
+}

--- a/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/auth_provider_data.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/auth_provider_data.dart
@@ -1,0 +1,23 @@
+/// In RedFire a [UserInfo] is converted to a [AuthProviderData] via UserInfo.toModel()
+
+class AuthProviderData {
+  AuthProviderData({
+    /// The provider identifier.
+    required String providerId,
+
+    /// The provider’s user ID for the user.
+    required String? uid,
+
+    /// The name of the user.
+    String? displayName,
+
+    /// The URL of the user’s profile photo.
+    String? photoURL,
+
+    /// The user’s email address.
+    String? email,
+
+    /// The user's phone number.
+    String? phoneNumber,
+  });
+}

--- a/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/auth_user_data.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/auth_user_data.dart
@@ -1,0 +1,20 @@
+import 'auth_provider_data.dart';
+
+/// This class was created in RedFire -> mapped from a User via `user.toModel();`
+
+/// [createdOn] and [lastSignedInOn] are in UTC as required for serialization
+class AuthUserData {
+  AuthUserData({
+    required String uid,
+    String? tenantId,
+    String? displayName,
+    String? photoURL,
+    String? email,
+    String? phoneNumber,
+    DateTime? createdOn,
+    DateTime? lastSignedInOn,
+    required bool isAnonymous,
+    required bool emailVerified,
+    required List<AuthProviderData> providers,
+  });
+}

--- a/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/id_token_result.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/id_token_result.dart
@@ -1,0 +1,50 @@
+/// Copied from: firebase_auth_platform_interface-6.5.2/lib/src/id_token_result.dart
+/// TODO: Review if this class also works for FirebaseAuthServiceRest
+
+/// Interface representing ID token result obtained from [getIdTokenResult].
+/// It contains the ID token JWT string and other helper properties for getting
+/// different data associated with the token as well as all the decoded payload
+/// claims.
+///
+/// Note that these claims are not to be trusted as they are parsed client side.
+/// Only server side verification can guarantee the integrity of the token
+/// claims.
+class IdTokenResult {
+  IdTokenResult(this._data);
+
+  final Map<String, dynamic> _data;
+
+  /// The authentication time formatted as UTC string. This is the time the user
+  /// authenticated (signed in) and not the time the token was refreshed.
+  DateTime? get authTime => _data['authTimestamp'] == null
+      ? null
+      : DateTime.fromMillisecondsSinceEpoch(_data['authTimestamp']);
+
+  /// The entire payload claims of the ID token including the standard reserved
+  /// claims as well as the custom claims.
+  Map<String, dynamic>? get claims => _data['claims'] == null
+      ? null
+      : Map<String, dynamic>.from(_data['claims']);
+
+  /// The time when the ID token expires.
+  DateTime? get expirationTime => _data['expirationTimestamp'] == null
+      ? null
+      : DateTime.fromMillisecondsSinceEpoch(_data['expirationTimestamp']);
+
+  /// The time when ID token was issued.
+  DateTime? get issuedAtTime => _data['issuedAtTimestamp'] == null
+      ? null
+      : DateTime.fromMillisecondsSinceEpoch(_data['issuedAtTimestamp']);
+
+  /// The sign-in provider through which the ID token was obtained (anonymous,
+  /// custom, phone, password, etc). Note, this does not map to provider IDs.
+  String? get signInProvider => _data['signInProvider'];
+
+  /// The Firebase Auth ID token JWT string.
+  String? get token => _data['token'];
+
+  @override
+  String toString() {
+    return '$IdTokenResult(authTime: $authTime, claims: ${claims.toString()}, expirationTime: $expirationTime, issuedAtTime: $issuedAtTime, signInProvider: $signInProvider, token: $token)';
+  }
+}

--- a/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/provider_credential.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/provider_credential.dart
@@ -1,0 +1,34 @@
+import 'package:firebase_auth_service_interface/src/enums/provider_enum.dart';
+
+/// `sign_in_with_apple` gives us an `AppleIdCredential` (called `credential` below)
+/// which is used to create an `OAuthProvider`, which is then used with
+/// `FirebaseAuth` to sign in:
+///
+/// ```dart
+/// oAuthCredential = OAuthProvider('apple.com').credential(
+///   accessToken: credential.authorizationCode,
+///   idToken: credential.identityToken,
+/// );
+/// FirebaseAuth.instance.signInWithCredential(oAuthCredential);
+/// ```
+///
+///
+/// `google_sign_in` gives us a `GoogleSignInAuthentication` (called `credential` below)
+/// which is used to create an `OAuthProvider`, which is then used with
+/// `FirebaseAuth` to sign in:
+///
+/// ```dart
+/// oAuthCredential = GoogleAuthProvider.credential(
+///   accessToken: credential.accessToken,
+///   idToken: credential.idToken,
+/// );
+///
+/// FirebaseAuth.instance.signInWithCredential(oAuthCredential);
+/// ```
+
+class ProviderCredential {
+  ProviderCredential(this.provider, this.accessToken, this.idToken);
+  final ProviderEnum provider;
+  final String accessToken;
+  final String idToken;
+}

--- a/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/user.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/user.dart
@@ -1,0 +1,114 @@
+import 'user_info.dart';
+import 'user_metadata.dart';
+
+/// Copied from: firebase_auth-3.6.2/lib/src/user.dart
+/// TODO: Check if this works for the REST client too
+
+/// The User class in FlutterFire's firebse_auth has a lot of functionality that
+/// should be in the service rather than the model IMO
+///
+/// Members:
+/// - MultiFactor
+/// Functions
+/// - delete
+/// - getIdToken
+/// - getIdTokenResult
+/// - linkWithCredential
+/// - linkWithPopup
+/// - linkWithPhoneNumber
+/// - reauthenticateWithCredential
+/// - reload
+/// - sendEmailVerification
+/// - unlink
+/// - updateEmail
+/// - updatePassword
+/// - updatePhoneNumber
+/// - updatePhotoURL
+/// - updateDisplayName
+/// - verifyBeforeUpdateEmail
+
+/// A user account.
+class User {
+  User(
+      this.displayName,
+      this.email,
+      this.emailVerified,
+      this.isAnonymous,
+      this.metadata,
+      this.phoneNumber,
+      this.photoURL,
+      this.providerData,
+      this.refreshToken,
+      this.tenantId,
+      this.uid);
+
+  /// The users display name.
+  ///
+  /// Will be `null` if signing in anonymously or via password authentication.
+  final String? displayName;
+
+  /// The users email address.
+  ///
+  /// Will be `null` if signing in anonymously.
+  final String? email;
+
+  /// Returns whether the users email address has been verified.
+  ///
+  /// To send a verification email, see [sendEmailVerification].
+  ///
+  /// Once verified, call [reload] to ensure the latest user information is
+  /// retrieved from Firebase.
+  final bool emailVerified;
+
+  /// Returns whether the user is a anonymous.
+  final bool isAnonymous;
+
+  /// Returns additional metadata about the user, such as their creation time.
+  final UserMetadata metadata;
+
+  /// Returns the users phone number.
+  ///
+  /// This property will be `null` if the user has not signed in or been has
+  /// their phone number linked.
+  final String? phoneNumber;
+
+  /// Returns a photo URL for the user.
+  ///
+  /// This property will be populated if the user has signed in or been linked
+  /// with a 3rd party OAuth provider (such as Google).
+  final String? photoURL;
+
+  /// Returns a list of user information for each linked provider.
+  final List<UserInfo> providerData;
+
+  /// Returns a JWT refresh token for the user.
+  ///
+  /// This property maybe `null` or empty if the underlying platform does not
+  /// support providing refresh tokens.
+  final String? refreshToken;
+
+  /// The current user's tenant ID.
+  ///
+  /// This is a read-only property, which indicates the tenant ID used to sign
+  /// in the current user. This is `null` if the user is signed in from the
+  /// parent project.
+  final String? tenantId;
+
+  /// The user's unique ID.
+  final String uid;
+
+  @override
+  String toString() {
+    return '$User('
+        'displayName: $displayName, '
+        'email: $email, '
+        'emailVerified: $emailVerified, '
+        'isAnonymous: $isAnonymous, '
+        'phoneNumber: $phoneNumber, '
+        'photoURL: $photoURL, '
+        'providerData, $providerData, '
+        'refreshToken: $refreshToken, '
+        'tenantId: $tenantId, '
+        'uid: $uid)';
+  }
+}

--- a/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/user_credential.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/user_credential.dart
@@ -1,0 +1,31 @@
+import 'additional_user_info.dart';
+import 'auth_credential.dart';
+import 'user.dart';
+
+/// Copied from firebase_auth-3.6.2/lib/src/user_credential.dart
+/// TODO: Check if this works for the REST client too
+
+/// A UserCredential is returned from authentication requests such as
+/// [createUserWithEmailAndPassword].
+class UserCredential {
+  UserCredential(this.additionalUserInfo, this.credential, this.user);
+
+  /// Returns additional information about the user, such as whether they are a
+  /// newly created one.
+  final AdditionalUserInfo? additionalUserInfo;
+
+  /// The users [AuthCredential].
+  final AuthCredential? credential;
+
+  /// Returns a [User] containing additional information and user specific
+  /// methods.
+  final User? user;
+
+  @override
+  String toString() {
+    return 'UserCredential('
+        'additionalUserInfo: $additionalUserInfo, '
+        'credential: $credential, '
+        'user: $user)';
+  }
+}

--- a/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/user_info.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/user_info.dart
@@ -1,0 +1,54 @@
+/// Copied from firebase_auth_platform_interface-6.5.2/lib/src/user_info.dart
+/// TODO: check if this works for the REST client too
+
+/// User profile information, visible only to the Firebase project's apps.
+class UserInfo {
+  UserInfo(this._data);
+
+  final Map<String, String?> _data;
+
+  /// The users display name.
+  ///
+  /// Will be `null` if signing in anonymously or via password authentication.
+  String? get displayName {
+    return _data['displayName'];
+  }
+
+  /// The users email address.
+  ///
+  /// Will be `null` if signing in anonymously.
+  String? get email {
+    return _data['email'];
+  }
+
+  /// Returns the users phone number.
+  ///
+  /// This property will be `null` if the user has not signed in or been has
+  /// their phone number linked.
+  String? get phoneNumber {
+    return _data['phoneNumber'];
+  }
+
+  /// Returns a photo URL for the user.
+  ///
+  /// This property will be populated if the user has signed in or been linked
+  /// with a 3rd party OAuth provider (such as Google).
+  String? get photoURL {
+    return _data['photoURL'];
+  }
+
+  /// The federated provider ID.
+  String get providerId {
+    return _data['providerId']!;
+  }
+
+  /// The user's unique ID.
+  String? get uid {
+    return _data['uid'];
+  }
+
+  @override
+  String toString() {
+    return '$UserInfo(displayName: $displayName, email: $email, phoneNumber: $phoneNumber, photoURL: $photoURL, providerId: $providerId, uid: $uid)';
+  }
+}

--- a/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/user_metadata.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/lib/src/models/user_metadata.dart
@@ -1,0 +1,28 @@
+/// Copied from: firebase_auth_platform_interface-6.5.2/lib/src/user_metadata.dart
+/// TODO: Check if this works for the REST Client too
+
+/// Interface representing a user's metadata.
+class UserMetadata {
+  UserMetadata(this._creationTimestamp, this._lastSignInTime);
+
+  final int? _creationTimestamp;
+  final int? _lastSignInTime;
+
+  /// When this account was created as dictated by the server clock.
+  DateTime? get creationTime => _creationTimestamp == null
+      ? null
+      : DateTime.fromMillisecondsSinceEpoch(_creationTimestamp!);
+
+  /// When the user last signed in as dictated by the server clock.
+  ///
+  /// This is only accurate up to a granularity of 2 minutes for consecutive
+  /// sign-in attempts.
+  DateTime? get lastSignInTime => _lastSignInTime == null
+      ? null
+      : DateTime.fromMillisecondsSinceEpoch(_lastSignInTime!);
+
+  @override
+  String toString() {
+    return 'UserMetadata(creationTime: ${creationTime.toString()}, lastSignInTime: ${lastSignInTime.toString()})';
+  }
+}

--- a/packages/dart/interfaces/firebase_auth_service_interface/pubspec.yaml
+++ b/packages/dart/interfaces/firebase_auth_service_interface/pubspec.yaml
@@ -1,0 +1,13 @@
+name: firebase_auth_service_interface
+description: An interface for a firebase auth service.
+version: 0.0.1
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+# dependencies:
+#   path: ^1.8.0
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.16.0

--- a/packages/dart/interfaces/firebase_auth_service_interface/test/firebase_auth_service_interface_test.dart
+++ b/packages/dart/interfaces/firebase_auth_service_interface/test/firebase_auth_service_interface_test.dart
@@ -1,0 +1,13 @@
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests', () {
+    setUp(() {
+      // Additional setup goes here.
+    });
+
+    test('First Test', () {
+      expect(true, isTrue);
+    });
+  });
+}

--- a/packages/dart/interfaces/firestore_service_interface/README.md
+++ b/packages/dart/interfaces/firestore_service_interface/README.md
@@ -1,6 +1,6 @@
 # firestore_service_interface
 
-An interface for a firesetore service allowing different implementations for
+An interface for a firestore service allowing different implementations for
 Flutter apps (FlutterFire) and Dart servers (googleapis.dart).
 
 <!-- 


### PR DESCRIPTION
I added a package that provides an interface for different
implementations of a FirebaseAuth service.  redfire already has such a
service, that uses flutterfire's firebase_auth package.

The reason for the interface is so that we can add other
implementations of a firebase auth service and use them interchangeably
where possible or just a single API surface to remember between
platforms.

Other implmentations that may be useful are one that uses
googleapis_auth or one that use the firebase auth REST API.