### PR TITLE
new(rds): Add redux_devtools_screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Three letter acronyms used in commit messages:
 - lcr = locator
 - oml = our_meals
 - rdx = enspyr_redux
+- rds = redux_devtools_screen
 - rfr = redfire
 - rft = redfire_test
 - rfl = redfire_lints

--- a/packages/flutter/utils/redux_devtools_screen/.gitignore
+++ b/packages/flutter/utils/redux_devtools_screen/.gitignore
@@ -1,0 +1,30 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.packages
+build/

--- a/packages/flutter/utils/redux_devtools_screen/.metadata
+++ b/packages/flutter/utils/redux_devtools_screen/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: 9758aa35b697bda7a6d6fc529012dcb928881d0f
+  channel: master
+
+project_type: package

--- a/packages/flutter/utils/redux_devtools_screen/CHANGELOG.md
+++ b/packages/flutter/utils/redux_devtools_screen/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+* TODO: Describe initial release.

--- a/packages/flutter/utils/redux_devtools_screen/LICENSE
+++ b/packages/flutter/utils/redux_devtools_screen/LICENSE
@@ -1,0 +1,1 @@
+TODO: Add your license here.

--- a/packages/flutter/utils/redux_devtools_screen/README.md
+++ b/packages/flutter/utils/redux_devtools_screen/README.md
@@ -1,0 +1,39 @@
+<!--
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages).
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages).
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder.
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to
+contribute to the package, how to file issues, what response they can expect
+from the package authors, and more.

--- a/packages/flutter/utils/redux_devtools_screen/analysis_options.yaml
+++ b/packages/flutter/utils/redux_devtools_screen/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/packages/flutter/utils/redux_devtools_screen/lib/redux_devtools_screen.dart
+++ b/packages/flutter/utils/redux_devtools_screen/lib/redux_devtools_screen.dart
@@ -1,0 +1,3 @@
+library redux_devtools_screen;
+
+export 'src/red_fire_stateful_widget.dart';

--- a/packages/flutter/utils/redux_devtools_screen/lib/src/action_history/action_history_item.dart
+++ b/packages/flutter/utils/redux_devtools_screen/lib/src/action_history/action_history_item.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class ActionHistoryItem extends StatelessWidget {
+  const ActionHistoryItem({
+    Key? key,
+    required this.actionName,
+    required this.actionState,
+    required this.onTap,
+    required this.currentlySelected,
+  }) : super(key: key);
+
+  final String actionName;
+  final Map<String, dynamic> actionState;
+  final Function onTap;
+  final bool currentlySelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(actionName),
+      subtitle: currentlySelected ? Text(actionState.toString()) : Container(),
+      onTap: () => onTap(),
+    );
+  }
+}

--- a/packages/flutter/utils/redux_devtools_screen/lib/src/action_history/actions_history_view.dart
+++ b/packages/flutter/utils/redux_devtools_screen/lib/src/action_history/actions_history_view.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+import '../events/events_model.dart';
+import 'action_history_item.dart';
+
+class ActionsHistoryView extends StatelessWidget {
+  const ActionsHistoryView(this._model);
+
+  final EventsModel _model;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 300,
+      child: ListView.builder(
+          itemCount: _model.events.length,
+          itemBuilder: (context, index) {
+            final actionMap = _model.events[index]['action'];
+            if (actionMap == null) {
+              return Container();
+            }
+            return ActionHistoryItem(
+                currentlySelected: index == _model.selectedIndex,
+                actionName: actionMap['description'],
+                actionState: actionMap['json'],
+                onTap: () => _model.setSelected(index));
+          }),
+    );
+  }
+}

--- a/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/app_state_view.dart
+++ b/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/app_state_view.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import '../events/events_model.dart';
+import 'state_tree/key_provider.dart';
+import 'state_tree/primitives/tree_controller.dart';
+import 'state_tree/primitives/tree_node.dart';
+import 'state_tree/widgets/tree_view.dart';
+
+class AppStateView extends StatelessWidget {
+  AppStateView(this._model);
+
+  final EventsModel _model;
+  final _keyProvider = KeyProvider();
+  final _controller = TreeController(allNodesExpanded: false);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: TreeView(
+        toTreeNodes(_model.selectedState, _model.previousState),
+        treeController: _controller,
+      ),
+    );
+  }
+
+  List<TreeNode> toTreeNodes(dynamic currentJson, dynamic previousJson) {
+    if (currentJson is Map<String, dynamic>) {
+      return currentJson.keys
+          .map(
+            (k) => TreeNode(
+              toTreeNodes(
+                currentJson[k],
+                (previousJson == null) ? null : previousJson[k],
+              ),
+              key: _keyProvider.nextKey(),
+              content: Text('$k:'),
+            ),
+          ) //
+          .toList();
+    }
+    if (currentJson is List<dynamic>) {
+      return currentJson
+          .asMap()
+          .map(
+            (i, element) => MapEntry(
+              i,
+              TreeNode(
+                toTreeNodes(
+                  element,
+                  previousJson == null || previousJson.isEmpty
+                      ? null
+                      : previousJson.elementAt(i),
+                ),
+                key: _keyProvider.nextKey(),
+                content: Text('[$i]:'),
+              ),
+            ),
+          ) //
+          .values
+          .toList();
+    }
+
+    // Not a map or list so leaf - save a key in case we want to use it
+    final key = _keyProvider.nextKey();
+    final changed = currentJson != previousJson;
+    if (changed) _controller.expandNode(key);
+    return [
+      TreeNode(
+        [],
+        key: key,
+        content: !changed // no change -> print in black
+            ? Text(currentJson.toString())
+            : previousJson == null // new value was added -> show in green
+                ? Text(currentJson.toString())
+                : Row(
+                    children: [
+                      Text(previousJson.toString(), style: oldStyle),
+                      const Icon(Icons.arrow_right_alt_rounded),
+                      Text(currentJson.toString(), style: newStyle)
+                    ],
+                  ),
+      ) // otherwise show difference
+    ];
+  }
+}
+
+final oldStyle = TextStyle(
+  fontSize: 20,
+  backgroundColor: Colors.red[200],
+  foreground: Paint()..color = Colors.red[700]!,
+  decoration: TextDecoration.lineThrough,
+  decorationColor: Colors.red[700],
+);
+
+final newStyle = TextStyle(
+  fontSize: 20,
+  backgroundColor: Colors.green[200],
+  foreground: Paint()..color = Colors.green[700]!,
+);

--- a/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/functions.dart
+++ b/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/functions.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/widgets.dart';
+
+import 'primitives/key_provider.dart';
+import 'primitives/tree_controller.dart';
+import 'primitives/tree_node.dart';
+import 'widgets/node_widget.dart';
+
+/// Builds set of [nodes] respecting [state], [indent] and [iconSize].
+Widget buildNodes(
+  Iterable<TreeNode> nodes,
+  double indent,
+  TreeController state,
+  double iconSize,
+) {
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      for (var node in nodes)
+        NodeWidget(
+          node,
+          state,
+          indent: indent,
+          iconSize: iconSize,
+        )
+    ],
+  );
+}
+
+/// Copies nodes to unmodifiable list, assigning missing keys and checking for duplicates.
+List<TreeNode> copyTreeNodes(List<TreeNode> nodes) {
+  return _copyNodesRecursively(nodes, KeyProvider());
+}
+
+List<TreeNode> _copyNodesRecursively(
+  List<TreeNode> nodes,
+  KeyProvider keyProvider,
+) {
+  return List.unmodifiable(
+    nodes.map((n) {
+      return TreeNode(
+        _copyNodesRecursively(n.children, keyProvider),
+        key: keyProvider.key(n.key),
+        content: n.content,
+      );
+    }),
+  );
+}

--- a/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/key_provider.dart
+++ b/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/key_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/foundation.dart';
+
+class KeyProvider {
+  int count = 0;
+
+  Key nextKey() => Key('${count++}');
+}

--- a/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/primitives/key_provider.dart
+++ b/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/primitives/key_provider.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+/// Provides unique keys and verifies duplicates.
+class KeyProvider {
+  int _nextIndex = 0;
+  final Set<Key> _keys = <Key>{};
+
+  /// If [originalKey] is null, generates new key, otherwise verifies the key
+  /// was not met before.
+  Key key(Key originalKey) {
+    if (originalKey == null) {
+      return _TreeNodeKey(_nextIndex++);
+    }
+    if (_keys.contains(originalKey)) {
+      throw ArgumentError('There should not be nodes with the same kays. '
+          'Duplicate value found: $originalKey.');
+    }
+    _keys.add(originalKey);
+    return originalKey;
+  }
+}
+
+class _TreeNodeKey extends ValueKey {
+  const _TreeNodeKey(dynamic value) : super(value);
+}

--- a/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/primitives/tree_controller.dart
+++ b/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/primitives/tree_controller.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/foundation.dart';
+
+class TreeController {
+  TreeController({allNodesExpanded = true})
+      : _allNodesExpanded = allNodesExpanded;
+
+  bool _allNodesExpanded;
+  final Map<Key, bool> _expanded = <Key, bool>{};
+
+  bool get allNodesExpanded => _allNodesExpanded;
+
+  bool isNodeExpanded(Key key) {
+    return _expanded[key] ?? _allNodesExpanded;
+  }
+
+  void toggleNodeExpanded(Key key) {
+    _expanded[key] = !isNodeExpanded(key);
+  }
+
+  void expandAll() {
+    _allNodesExpanded = true;
+    _expanded.clear();
+  }
+
+  void collapseAll() {
+    _allNodesExpanded = false;
+    _expanded.clear();
+  }
+
+  void expandNode(Key key) {
+    _expanded[key] = true;
+  }
+
+  void collapseNode(Key key) {
+    _expanded[key] = false;
+  }
+}

--- a/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/primitives/tree_node.dart
+++ b/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/primitives/tree_node.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/widgets.dart';
+
+class TreeNode {
+  TreeNode(this.children, {required this.key, Widget? content})
+      : content = content ?? Container(width: 0, height: 0);
+
+  final Key key;
+  final List<TreeNode> children;
+  final Widget content;
+
+  bool get isLeaf => children.isEmpty;
+  bool get hasSingleLeafChild => children.length == 1 && children.first.isLeaf;
+}

--- a/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/widgets/node_widget.dart
+++ b/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/widgets/node_widget.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+import '../functions.dart';
+import '../primitives/tree_controller.dart';
+import '../primitives/tree_node.dart';
+
+/// Widget that displays one [TreeNode] and its children.
+class NodeWidget extends StatefulWidget {
+  const NodeWidget(
+    this.treeNode,
+    this.state, {
+    Key? key,
+    this.indent = 0.0,
+    this.iconSize = 18.0,
+  }) : super(key: key);
+
+  final TreeNode treeNode;
+  final double indent;
+  final double iconSize;
+  final TreeController state;
+
+  @override
+  _NodeWidgetState createState() => _NodeWidgetState();
+}
+
+class _NodeWidgetState extends State<NodeWidget> {
+  bool get _isExpanded => widget.state.isNodeExpanded(widget.treeNode.key);
+  bool get _isLeaf => widget.treeNode.isLeaf;
+  bool get _hasSingleLeafChild => widget.treeNode.hasSingleLeafChild;
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = _isLeaf || _hasSingleLeafChild
+        ? null
+        : _isExpanded
+            ? Icons.arrow_drop_down
+            : Icons.arrow_right;
+
+    final onIconPressed = _isLeaf
+        ? null
+        : () => setState(
+              () => widget.state.toggleNodeExpanded(widget.treeNode.key),
+            );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            IconButton(
+              iconSize: widget.iconSize,
+              icon: Icon(icon),
+              onPressed: onIconPressed,
+              hoverColor: Colors.transparent,
+              highlightColor: Colors.transparent,
+              splashColor: Colors.transparent,
+            ),
+            GestureDetector(
+              onTap: onIconPressed,
+              child: widget.treeNode.content,
+            ),
+            if (_hasSingleLeafChild)
+              Padding(
+                padding: const EdgeInsets.only(left: 10),
+                child: widget.treeNode.children.first.content,
+              )
+          ],
+        ),
+        if (_isExpanded && !_isLeaf && !_hasSingleLeafChild)
+          Padding(
+            padding: EdgeInsets.only(left: widget.indent),
+            child: buildNodes(
+              widget.treeNode.children,
+              widget.indent,
+              widget.state,
+              widget.iconSize,
+            ),
+          )
+      ],
+    );
+  }
+}

--- a/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/widgets/tree_view.dart
+++ b/packages/flutter/utils/redux_devtools_screen/lib/src/app_state/state_tree/widgets/tree_view.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+import '../functions.dart';
+import '../primitives/tree_controller.dart';
+import '../primitives/tree_node.dart';
+
+/// Tree view with collapsible and expandable nodes.
+class TreeView extends StatefulWidget {
+  TreeView(
+    List<TreeNode> nodes, {
+    Key? key,
+    this.indent = 40.0,
+    this.iconSize = 18.0,
+    this.treeController,
+  })  : nodes = copyTreeNodes(nodes),
+        super(key: key);
+
+  /// List of root level tree nodes.
+  final List<TreeNode> nodes;
+
+  /// Horizontal indent between levels.
+  final double indent;
+
+  /// Size of the expand/collapse icon.
+  final double iconSize;
+
+  /// Tree controller to manage the tree state.
+  final TreeController? treeController;
+
+  @override
+  _TreeViewState createState() => _TreeViewState();
+}
+
+class _TreeViewState extends State<TreeView> {
+  late TreeController _controller;
+
+  @override
+  void initState() {
+    _controller = widget.treeController ?? TreeController();
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return buildNodes(
+      widget.nodes,
+      widget.indent,
+      _controller,
+      widget.iconSize,
+    );
+  }
+}

--- a/packages/flutter/utils/redux_devtools_screen/lib/src/events/events_model.dart
+++ b/packages/flutter/utils/redux_devtools_screen/lib/src/events/events_model.dart
@@ -1,0 +1,35 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+class EventsModel extends ChangeNotifier {
+  // Internal state.
+  final List<Map<String, dynamic>> _events = [];
+  int? _selectedIndex;
+
+  // Getters for reading state.
+  UnmodifiableListView<Map<String, dynamic>> get events =>
+      UnmodifiableListView(_events);
+  int? get selectedIndex => _selectedIndex;
+  Map<String, dynamic> get selectedState =>
+      (_selectedIndex == null) ? {} : _events[_selectedIndex!]['state_json'];
+  Map<String, dynamic> get previousState =>
+      (_selectedIndex == null || _selectedIndex == 0)
+          ? {}
+          : _events[_selectedIndex! - 1]['state_json'];
+
+  void setSelected(int index) {
+    _selectedIndex = index;
+    notifyListeners();
+  }
+
+  void add(Map<String, dynamic> event) {
+    _events.add(event);
+    notifyListeners();
+  }
+
+  void removeAll() {
+    _events.clear();
+    notifyListeners();
+  }
+}

--- a/packages/flutter/utils/redux_devtools_screen/lib/src/red_fire_stateful_widget.dart
+++ b/packages/flutter/utils/redux_devtools_screen/lib/src/red_fire_stateful_widget.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:vm_service/vm_service.dart';
+
+import 'action_history/actions_history_view.dart';
+import 'app_state/app_state_view.dart';
+import 'events/events_model.dart';
+
+/// Requires `serviceManager.service!.onExtensionEvent` to be passed in.
+///
+/// Listens to a [Stream] of events from [redfire] and keeps
+/// a [StreamSubscription] for canceling on dispose.
+///
+/// Events consist of an action and the corresponding app state.
+///
+/// Each event is added to the [EventsModel] which is passed down for display
+/// by child widgets.
+class RedFireStatefulWidget extends StatefulWidget {
+  const RedFireStatefulWidget(this.eventsStream, {Key? key}) : super(key: key);
+
+  final Stream<Event> eventsStream;
+
+  @override
+  State<RedFireStatefulWidget> createState() => _RedFireStatefulWidgetState();
+}
+
+class _RedFireStatefulWidgetState extends State<RedFireStatefulWidget> {
+  final _model = EventsModel();
+  StreamSubscription<Event>? _eventsSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _eventsSubscription = widget.eventsStream
+        .where((event) => event.extensionKind?.startsWith('redfire:') ?? false)
+        .listen((event) {
+      if (event.extensionKind == 'redfire:action_dispatched') {
+        _model.add(event.extensionData!.data);
+      } else if (event.extensionKind == 'redfire:remove_all') {
+        _model.removeAll();
+      }
+    });
+    _model.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _eventsSubscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(children: [ActionsHistoryView(_model), AppStateView(_model)]);
+  }
+}

--- a/packages/flutter/utils/redux_devtools_screen/pubspec.yaml
+++ b/packages/flutter/utils/redux_devtools_screen/pubspec.yaml
@@ -1,0 +1,55 @@
+name: redux_devtools_screen
+description: A new Flutter package project.
+version: 0.0.1
+homepage:
+
+environment:
+  sdk: '>=2.19.0-100.0.dev <3.0.0'
+  flutter: ">=1.17.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  vm_service: ^9.3.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+# For information on the generic Dart part of this file, see the
+# following page: https://dart.dev/tools/pub/pubspec
+
+# The following section is specific to Flutter packages.
+flutter:
+
+  # To add assets to your package, add an assets section, like this:
+  # assets:
+  #   - images/a_dot_burr.jpeg
+  #   - images/a_dot_ham.jpeg
+  #
+  # For details regarding assets in packages, see
+  # https://flutter.dev/assets-and-images/#from-packages
+  #
+  # An image asset can refer to one or more resolution-specific "variants", see
+  # https://flutter.dev/assets-and-images/#resolution-aware
+
+  # To add custom fonts to your package, add a fonts section here,
+  # in this "flutter" section. Each entry in this list should have a
+  # "family" key with the font family name, and a "fonts" key with a
+  # list giving the asset and other descriptors for the font. For
+  # example:
+  # fonts:
+  #   - family: Schyler
+  #     fonts:
+  #       - asset: fonts/Schyler-Regular.ttf
+  #       - asset: fonts/Schyler-Italic.ttf
+  #         style: italic
+  #   - family: Trajan Pro
+  #     fonts:
+  #       - asset: fonts/TrajanPro.ttf
+  #       - asset: fonts/TrajanPro_Bold.ttf
+  #         weight: 700
+  #
+  # For details regarding fonts in packages, see
+  # https://flutter.dev/custom-fonts/#from-packages

--- a/packages/flutter/utils/redux_devtools_screen/test/redux_devtools_screen_test.dart
+++ b/packages/flutter/utils/redux_devtools_screen/test/redux_devtools_screen_test.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('...', () {
+    expect(true, isTrue);
+  });
+}


### PR DESCRIPTION
This is a flutter package that exports a single widget - providing
an interactive visualization of the app state history for apps using
redux, as part of a Flutter Devtools plugin.