### PR TITLE
chore(rds): update dart dep to 2.17 for flutter stable

### DIFF
--- a/packages/flutter/utils/redux_devtools_screen/pubspec.yaml
+++ b/packages/flutter/utils/redux_devtools_screen/pubspec.yaml
@@ -4,8 +4,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
-  flutter: ">=1.17.0"
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   collection: ^1.16.0


### PR DESCRIPTION
The package was created with flutter on master channel which is now
breaking other projects so back to stable and reduce the Dart SDK
constraint.