### PR TITLE
feat(rfr): Add Redux DevTools Screen

### DIFF
--- a/packages/flutter/utils/redfire/lib/src/app-init/widgets/app_widget.dart
+++ b/packages/flutter/utils/redfire/lib/src/app-init/widgets/app_widget.dart
@@ -3,6 +3,8 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:redux/redux.dart';
+import 'package:redux_devtools_screen/redux_devtools_screen.dart';
+import 'package:split_view/split_view.dart';
 
 import '../../auth/utils/login_configs.dart';
 import '../../navigation/actions/remove_current_page_action.dart';
@@ -15,6 +17,7 @@ import '../../settings/extensions/theme_set_extensions.dart';
 import '../../settings/models/settings.dart';
 import '../../types/red_fire_state.dart';
 import '../../types/redux_action.dart';
+import '../../utils/devtools_global.dart';
 import '../../utils/red_fire_config.dart';
 import '../../utils/red_fire_locator.dart';
 import '../redux/redfire_initial_actions.dart';
@@ -125,18 +128,23 @@ class _AppWidgetState<T extends RedFireState> extends State<AppWidget<T>> {
     return StoreProvider<T>(
       store: widget._store,
       child: StoreConnector<T, Settings>(
-          distinct: true,
-          converter: (store) => store.state.settings,
-          builder: (context, settings) {
-            return MaterialApp(
-              title: widget._title,
-              theme: settings.lightTheme.data,
-              darkTheme: settings.darkTheme.data,
-              themeMode: settings.brightnessMode.theme,
-              home: StoreConnector<T, IList<PageData>>(
-                distinct: true,
-                converter: (store) => store.state.pages,
-                builder: (context, pages) => Navigator(
+        distinct: true,
+        converter: (store) => store.state.settings,
+        builder: (context, settings) {
+          return MaterialApp(
+            title: widget._title,
+            theme: settings.lightTheme.data,
+            darkTheme: settings.darkTheme.data,
+            themeMode: settings.brightnessMode.theme,
+            home: SplitView(
+              viewMode: SplitViewMode.Horizontal,
+              children: [
+                Material(
+                    child: ReduxDevToolsScreen(reduxEventsController.stream)),
+                StoreConnector<T, IList<PageData>>(
+                  distinct: true,
+                  converter: (store) => store.state.pages,
+                  builder: (context, pages) => Navigator(
                     pages: pages.toPages<T>(),
                     onPopPage: (route, dynamic result) {
                       if (!route.didPop(result)) {
@@ -148,10 +156,14 @@ class _AppWidgetState<T extends RedFireState> extends State<AppWidget<T>> {
                       }
 
                       return true;
-                    }),
-              ),
-            );
-          }),
+                    },
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/packages/flutter/utils/redfire/lib/src/utils/dev_tools_middleware.dart
+++ b/packages/flutter/utils/redfire/lib/src/utils/dev_tools_middleware.dart
@@ -1,9 +1,11 @@
 import 'dart:developer';
 
 import 'package:redux/redux.dart';
+import 'package:redux_devtools_screen/redux_devtools_screen.dart';
 
 import '../types/red_fire_state.dart';
 import '../types/redux_action.dart';
+import 'devtools_global.dart';
 
 class DevToolsMiddleware<T extends RedFireState>
     extends TypedMiddleware<T, ReduxAction> {
@@ -11,13 +13,30 @@ class DevToolsMiddleware<T extends RedFireState>
       : super((store, action, next) async {
           next(action);
 
-          postEvent('redfire:action_dispatched', <String, Object?>{
+          final className = action.toString();
+          String actionName = className[0];
+          int i = 1;
+          while (i < className.length) {
+            if (className[i] == '(') break;
+            if (className[i] == className[i].toUpperCase()) actionName += ' ';
+            actionName += className[i];
+            i++;
+          }
+          actionName = actionName.substring(0, actionName.length - 7);
+
+          var data = <String, Object?>{
             'state_json': store.state.toJson(),
-            'action': {
-              'description': action.toString().split('(').first,
-              'json': action.toJson()
-            }
-          });
+            'action': {'description': actionName, 'json': action.toJson()}
+          };
+
+          // Post an event with state change information that our
+          // Flutter DevTools plugin can listen for.
+          postEvent('redfire:action_dispatched', data);
+
+          // Add an event with state change information to the stream that
+          // we pass in to the ReduxDevToolsScreen, in AppWidget.
+          reduxEventsController.add(
+              ReduxStateEvent(data: data, type: 'redfire:action_dispatched'));
         }) {
     // When the middleware is created, send an event to clear data from devtools.
     // This is useful when user performs a hot restart.

--- a/packages/flutter/utils/redfire/lib/src/utils/devtools_global.dart
+++ b/packages/flutter/utils/redfire/lib/src/utils/devtools_global.dart
@@ -1,0 +1,5 @@
+import 'dart:async';
+
+import 'package:redux_devtools_screen/redux_devtools_screen.dart';
+
+final reduxEventsController = StreamController<ReduxStateEvent>.broadcast();

--- a/packages/flutter/utils/redfire/pubspec.yaml
+++ b/packages/flutter/utils/redfire/pubspec.yaml
@@ -30,6 +30,11 @@ dependencies:
     git:
       url: https://github.com/enspyrco/monorepo.git
       path: packages/flutter/utils/flutterfire/cloud_firestore_extensions
+  split_view: ^3.2.1
+  redux_devtools_screen:
+    git:
+      url: https://github.com/enspyrco/monorepo.git
+      path: packages/flutter/utils/redux_devtools_screen
   
 dev_dependencies:
   flutter_test:

--- a/packages/flutter/utils/redfire/pubspec_overrides.yaml
+++ b/packages/flutter/utils/redfire/pubspec_overrides.yaml
@@ -7,3 +7,5 @@ dependency_overrides:
     path: ../../../dart/interfaces/firestore_service_interface
   cloud_firestore_extensions:
     path: ../flutterfire/cloud_firestore_extensions
+  redux_devtools_screen:
+    path: ../redux_devtools_screen


### PR DESCRIPTION
The redux_devtools_screen package was extracted from the Redux DevTools
Plugin, which was being developed in a fork of the Flutter DevTools
(as the plugin architecture has not arrived just yet).  This was done so
we can have a common package shared by the plugin and redfire.

In redfire we put the ReduxDevToolsScreen alongside the MainScreen with
a SplitView so the DevTools is visible while we interact with the app.

I added a global stream controller which is used in the
DevToolsMiddleware (to send events) and in the ReduxDevToolsScreen
(to receive events). In a future PR I'll add our new locate package and
and change the global to be in a service locator.