### PR TITLE
Add Sync and Async actions, refactor & clean up

### DIFF
--- a/packages/dart/utils/redaux/lib/redaux.dart
+++ b/packages/dart/utils/redaux/lib/redaux.dart
@@ -3,62 +3,8 @@
 /// More dartdocs go here.
 library redaux;
 
-import 'dart:async';
-
-abstract class Action<S extends State> {
-  const Action();
-  Reducer<S>? get reducer;
-  Middleware<S>? get middleware;
-}
-
-abstract class Middleware<S extends State> {
-  void call(Store<S> store, Action<S> action);
-}
-
-abstract class Reducer<S extends State> {
-  S call(S state, Action<S> action);
-}
-
-abstract class State {}
-
-abstract class ReduxService {}
-
-class Store<S extends State> {
-  Store({
-    required S state,
-    StreamController<S>? streamController,
-  })  : _state = state,
-        _streamController = streamController ?? StreamController<S>();
-
-  S _state;
-
-  final StreamController<S> _streamController;
-
-  /// Returns the current state tree of the application.
-  /// It is equal to the last value returned by the store's reducer.
-  S get state => _state;
-
-  /// Dispatches a [Action]. This is the only way to trigger a state change.
-  /// Arguments:
-  /// - [action]: A plain object describing the change that makes sense for the
-  ///   application.
-  ///
-  ///   Actions are the only way to get data into the store, so any data,
-  ///   whether from the UI events, network callbacks, or other sources such as
-  ///   WebSockets needs to eventually be dispatched as actions. Actions must
-  ///   inherit from or implement [Action].
-  ///
-  /// See: https://redux.js.org/api/store#dispatchaction
-  void dispatch(Action<S> action) {
-    // let the middleware go free
-    action.middleware?.call(this, action);
-
-    // reduce if there is a reducer
-    _state = action.reducer?.call(_state, action) ?? _state;
-
-    // put an event in the stream with the new state
-    _streamController.add(_state);
-  }
-
-  Stream<S> get stateChanges => _streamController.stream;
-}
+export 'src/action.dart';
+export 'src/middleware.dart';
+export 'src/reducer.dart';
+export 'src/state.dart';
+export 'src/store.dart';

--- a/packages/dart/utils/redaux/lib/src/action.dart
+++ b/packages/dart/utils/redaux/lib/src/action.dart
@@ -1,0 +1,15 @@
+import 'middleware.dart';
+import 'reducer.dart';
+import 'state.dart';
+
+class Action {
+  final List<AsyncAction> history = [];
+}
+
+abstract class SyncAction<S extends State> extends Action {
+  Reducer<S>? get reducer;
+}
+
+abstract class AsyncAction<S extends State> extends Action {
+  Middleware<S>? get middleware;
+}

--- a/packages/dart/utils/redaux/lib/src/middleware.dart
+++ b/packages/dart/utils/redaux/lib/src/middleware.dart
@@ -1,0 +1,7 @@
+import 'action.dart';
+import 'state.dart';
+import 'store.dart';
+
+abstract class Middleware<S extends State> {
+  void call(Store<S> store, AsyncAction<S> action);
+}

--- a/packages/dart/utils/redaux/lib/src/reducer.dart
+++ b/packages/dart/utils/redaux/lib/src/reducer.dart
@@ -1,0 +1,6 @@
+import 'action.dart';
+import 'state.dart';
+
+abstract class Reducer<S extends State> {
+  S call(S state, SyncAction<S> action);
+}

--- a/packages/dart/utils/redaux/lib/src/state.dart
+++ b/packages/dart/utils/redaux/lib/src/state.dart
@@ -1,0 +1,1 @@
+abstract class State {}

--- a/packages/dart/utils/redaux/lib/src/store.dart
+++ b/packages/dart/utils/redaux/lib/src/store.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+
+import 'action.dart';
+import 'state.dart';
+
+class Store<S extends State> {
+  Store({
+    required S state,
+    StreamController<S>? streamController,
+  })  : _state = state,
+        _streamController = streamController ?? StreamController<S>();
+
+  S _state;
+
+  final StreamController<S> _streamController;
+
+  /// Returns the current state tree of the application.
+  /// It is equal to the last value returned by the store's reducer.
+  S get state => _state;
+
+  /// Dispatches an [Action]. This is the only way to trigger a state change.
+  /// Arguments:
+  /// - [action]: A plain object describing the action the store should take,
+  ///             either call a middleware for async or reducer for sync actions
+  ///
+  ///   Actions are the only way to upate the app state held in the store, so
+  ///   any data, whether from UI events, network callbacks, or other sources
+  ///   such as WebSockets needs to eventually be dispatched as sync actions to
+  ///   update the app state.
+  ///
+  ///   Actions must extend or implement either [AsyncAction] or [SyncAction],
+  ///   each of which inherit from [Action].
+  ///
+  /// See: https://redux.js.org/api/store#dispatchaction
+  void dispatch(Action action) {
+    // call middleware for async actions
+    if (action is AsyncAction<S>) {
+      action.middleware?.call(this, action);
+    }
+
+    // call reducer for sync actions
+    if (action is SyncAction<S>) {
+      _state = action.reducer?.call(_state, action) ?? _state;
+    }
+
+    // put an event in the stream with the new state
+    _streamController.add(_state);
+  }
+
+  Stream<S> get stateChanges => _streamController.stream;
+}

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/services/firebase_auth_service.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/services/firebase_auth_service.dart
@@ -1,11 +1,10 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:redaux/redaux.dart';
 
 import '../../utils/types.dart';
 import '../extensions/user_extension.dart';
 import '../state/user_state.dart';
 
-class FirebaseAuthService implements ReduxService {
+class FirebaseAuthService {
   FirebaseAuthService(this.plugin);
 
   FirebaseAuth plugin;

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/services/sign_in_with_apple_service.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/services/sign_in_with_apple_service.dart
@@ -1,9 +1,8 @@
-import 'package:redaux/redaux.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart' as plugin;
 
 import '../../utils/types.dart';
 
-class SignInWithAppleService implements ReduxService {
+class SignInWithAppleService {
   // late final String _nonce;
   // late final String _rawNonce;
 

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/bind_auth_state.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/bind_auth_state.dart
@@ -8,19 +8,14 @@ import '../services/firebase_auth_service.dart';
 import '../state/user_state.dart';
 import 'update_user_state.dart';
 
-class TapIntoAuthStateAction extends Action<AppState> {
-  const TapIntoAuthStateAction();
-  static final Middleware<AppState> _m = TapIntoAuthStateMiddleware();
-  static const Reducer<AppState>? _r = null;
+class BindAuthState extends AsyncAction<AppState> {
+  static final Middleware<AppState> _m = BindAuthStateMiddleware();
 
   @override
   Middleware<AppState>? get middleware => _m;
-
-  @override
-  Reducer<AppState>? get reducer => _r;
 }
 
-class TapIntoAuthStateMiddleware extends Middleware<AppState> {
+class BindAuthStateMiddleware extends Middleware<AppState> {
   StreamSubscription<UserState>? subscription;
 
   @override
@@ -29,6 +24,6 @@ class TapIntoAuthStateMiddleware extends Middleware<AppState> {
 
     subscription = service
         .tapIntoAuthState()
-        .listen((user) => store.dispatch(UpdateUserStateAction(user)));
+        .listen((user) => store.dispatch(UpdateUserState(user)));
   }
 }

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/sign_in_with_apple.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/sign_in_with_apple.dart
@@ -1,33 +1,32 @@
 import 'package:redaux/redaux.dart';
-import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart' as plugin;
 
 import '../../app_state.dart';
 import 'sign_in_with_firebase.dart';
 
-class SignInWithAppleAction extends Action<AppState> {
+class SignInWithApple extends AsyncAction<AppState> {
   static final Middleware<AppState> _m = SignInWithAppleMiddleware();
-  static const Reducer<AppState>? _r = null;
 
   @override
   Middleware<AppState>? get middleware => _m;
 
   @override
-  Reducer<AppState>? get reducer => _r;
+  final List<AsyncAction> history = [];
 }
 
 class SignInWithAppleMiddleware extends Middleware<AppState> {
   @override
-  void call(store, covariant SignInWithAppleAction action) async {
-    final AuthorizationCredentialAppleID credential =
-        await SignInWithApple.getAppleIDCredential(
+  void call(store, covariant SignInWithApple action) async {
+    final plugin.AuthorizationCredentialAppleID credential =
+        await plugin.SignInWithApple.getAppleIDCredential(
       scopes: [
-        AppleIDAuthorizationScopes.email,
-        AppleIDAuthorizationScopes.fullName,
+        plugin.AppleIDAuthorizationScopes.email,
+        plugin.AppleIDAuthorizationScopes.fullName,
       ],
     );
 
     var token = credential.identityToken ?? (throw 'a');
 
-    store.dispatch(SignInWithFirebaseAction(idToken: token));
+    store.dispatch(SignInWithFirebase(idToken: token));
   }
 }

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/sign_in_with_firebase.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/sign_in_with_firebase.dart
@@ -2,22 +2,18 @@ import 'package:redaux/redaux.dart';
 
 import '../../app_state.dart';
 
-class SignInWithFirebaseAction extends Action<AppState> {
+class SignInWithFirebase extends AsyncAction<AppState> {
   final String idToken;
 
-  SignInWithFirebaseAction({required this.idToken});
+  SignInWithFirebase({required this.idToken});
 
   static final Middleware<AppState> _m = SignInWithFirebaseMiddleware();
-  static const Reducer<AppState>? _r = null;
 
   @override
   Middleware<AppState>? get middleware => _m;
-
-  @override
-  Reducer<AppState>? get reducer => _r;
 }
 
 class SignInWithFirebaseMiddleware extends Middleware<AppState> {
   @override
-  void call(store, covariant SignInWithFirebaseAction action) {}
+  void call(store, covariant SignInWithFirebase action) {}
 }

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/update_user_state.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/update_user_state.dart
@@ -3,16 +3,12 @@ import 'package:redaux/redaux.dart';
 import '../../app_state.dart';
 import '../state/user_state.dart';
 
-class UpdateUserStateAction extends Action<AppState> {
+class UpdateUserState extends SyncAction<AppState> {
   final UserState user;
 
-  UpdateUserStateAction(this.user);
+  UpdateUserState(this.user);
 
-  static const Middleware<AppState>? _m = null;
   static final Reducer<AppState> _r = UpdateUserStateReducer();
-
-  @override
-  Middleware<AppState>? get middleware => _m;
 
   @override
   Reducer<AppState>? get reducer => _r;
@@ -20,6 +16,6 @@ class UpdateUserStateAction extends Action<AppState> {
 
 class UpdateUserStateReducer extends Reducer<AppState> {
   @override
-  AppState call(state, covariant UpdateUserStateAction action) =>
+  AppState call(state, covariant UpdateUserState action) =>
       state.copyWith(user: action.user);
 }

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/widgets/sign_in_screen.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/widgets/sign_in_screen.dart
@@ -17,8 +17,8 @@ class SignInScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     if (signedIn == SignedInState.notSignedIn) {
       return plugin.SignInWithAppleButton(
-          onPressed: () => StoreProvider.of<AppState>(context)
-              .dispatch(SignInWithAppleAction()));
+          onPressed: () =>
+              StoreProvider.of<AppState>(context).dispatch(SignInWithApple()));
     }
     return const CircularProgressIndicator();
   }

--- a/packages/flutter/apps/experiments/our_meals/lib/main.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:locator/locator.dart';
-import 'package:our_meals/auth/state_management/tap_into_auth_state.dart';
+import 'package:our_meals/auth/state_management/bind_auth_state.dart';
 import 'package:our_meals/auth/widgets/sign_in_screen.dart';
 import 'package:our_meals/firebase_options.dart';
 import 'package:our_meals/home/home_screen.dart';
@@ -44,7 +44,7 @@ class AuthGate extends StatelessWidget {
             }
             return const HomeScreen();
           },
-          onInit: (store) => store.dispatch(const TapIntoAuthStateAction()),
+          onInit: (store) => store.dispatch(BindAuthState()),
         ),
       ),
     );


### PR DESCRIPTION
I broke apart the single file in redaux, to follow best practice
(or perhaps just my preferred style).

I removed the ReduxService type from redaux as there doesn't seem to
be an advantage of services having the same supertype but there is a
disadvantage of coupling them to redaux.

I removed the 'Action' from the actions and made some notes on style
choice in the docs. It kind of just feels cleaner.

The user defined actions now inherit from either AsyncAction (which
 has a Middleware member) or SyncAction (which has a Reducer member)

 I added a 'history' member to the Action super-type to hold
 AsyncActions, which will be used to keep a record of the sequence of
 actions resulting in a state change, for better visualisations in
devtools.