### PR TITLE
refactor(+): Add RootState & safeAsyncCall, update our_meals

### DIFF
--- a/packages/dart/utils/redaux/lib/src/action.dart
+++ b/packages/dart/utils/redaux/lib/src/action.dart
@@ -6,10 +6,10 @@ class Action {
   final List<AsyncAction> history = [];
 }
 
-abstract class SyncAction<S extends State> extends Action {
-  Reducer<S>? get reducer;
+abstract class SyncAction<S extends RootState> extends Action {
+  Reducer<S> get reducer;
 }
 
-abstract class AsyncAction<S extends State> extends Action {
-  Middleware<S>? get middleware;
+abstract class AsyncAction<S extends RootState> extends Action {
+  Middleware<S> get middleware;
 }

--- a/packages/dart/utils/redaux/lib/src/middleware.dart
+++ b/packages/dart/utils/redaux/lib/src/middleware.dart
@@ -2,6 +2,7 @@ import 'action.dart';
 import 'state.dart';
 import 'store.dart';
 
-abstract class Middleware<S extends State> {
+abstract class Middleware<S extends RootState> {
+  const Middleware();
   void call(Store<S> store, AsyncAction<S> action);
 }

--- a/packages/dart/utils/redaux/lib/src/reducer.dart
+++ b/packages/dart/utils/redaux/lib/src/reducer.dart
@@ -1,6 +1,6 @@
 import 'action.dart';
 import 'state.dart';
 
-abstract class Reducer<S extends State> {
+abstract class Reducer<S extends RootState> {
   S call(S state, SyncAction<S> action);
 }

--- a/packages/dart/utils/redaux/lib/src/state.dart
+++ b/packages/dart/utils/redaux/lib/src/state.dart
@@ -1,1 +1,11 @@
-abstract class State {}
+import '../redaux.dart';
+
+abstract class State {
+  State copyWith();
+}
+
+abstract class RootState extends State {
+  List<ErrorMessage> errorMessages = [];
+  @override
+  RootState copyWith({List<ErrorMessage>? errorMessages});
+}

--- a/packages/flutter/apps/experiments/our_meals/lib/app/state/app_state.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/app/state/app_state.dart
@@ -1,15 +1,16 @@
 import 'package:redaux/redaux.dart';
 
-import 'auth/state/user_state.dart';
+import '../../auth/state/user_state.dart';
 
-class AppState extends State {
+class AppState extends RootState {
   static AppState get initial => AppState(user: UserState.initial);
 
   AppState({required this.user});
 
   UserState user;
 
-  AppState copyWith({UserState? user}) {
+  @override
+  AppState copyWith({List<ErrorMessage>? errorMessages, UserState? user}) {
     return AppState(user: user ?? this.user);
   }
 }

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/services/sign_in_with_apple_service.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/services/sign_in_with_apple_service.dart
@@ -3,16 +3,6 @@ import 'package:sign_in_with_apple/sign_in_with_apple.dart' as plugin;
 import '../../utils/types.dart';
 
 class SignInWithAppleService {
-  // late final String _nonce;
-  // late final String _rawNonce;
-
-  // // To prevent replay attacks with the credential returned from Apple, we
-  // // include a nonce in the credential request. When signing in with
-  // // Firebase, the nonce in the id token returned by Apple, is expected to
-  // // match the sha256 hash of `rawNonce`.
-  // final _rawNonce = generateNonce();
-  // final _nonce = sha256ofString(_rawNonce);
-
   // Request credential for the currently signed in Apple account.
   Future<AppleCredential> signInWithApple(String nonce) async {
     final appleCredential = await plugin.SignInWithApple.getAppleIDCredential(

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/bind_auth_state.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/bind_auth_state.dart
@@ -2,22 +2,20 @@ import 'dart:async';
 
 import 'package:redaux/redaux.dart';
 
-import '../../app_state.dart';
+import '../../app/state/app_state.dart';
 import '../../utils/locate.dart';
 import '../services/firebase_auth_service.dart';
 import '../state/user_state.dart';
 import 'update_user_state.dart';
 
 class BindAuthState extends AsyncAction<AppState> {
-  static final Middleware<AppState> _m = BindAuthStateMiddleware();
-
   @override
-  Middleware<AppState>? get middleware => _m;
+  Middleware<AppState> get middleware => _BindAuthStateMiddleware.instance;
 }
 
-class BindAuthStateMiddleware extends Middleware<AppState> {
-  StreamSubscription<UserState>? subscription;
-
+/// A file private singleton, allowing each [BindAuthState] action to return
+/// the appropriate Middleware.
+class _BindAuthStateMiddleware extends Middleware<AppState> {
   @override
   void call(store, action) {
     var service = locate<FirebaseAuthService>();
@@ -26,4 +24,8 @@ class BindAuthStateMiddleware extends Middleware<AppState> {
         .tapIntoAuthState()
         .listen((user) => store.dispatch(UpdateUserState(user)));
   }
+
+  StreamSubscription<UserState>? subscription;
+
+  static final instance = _BindAuthStateMiddleware();
 }

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/sign_in_with_firebase.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/sign_in_with_firebase.dart
@@ -1,19 +1,39 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:our_meals/auth/services/firebase_auth_service.dart';
+import 'package:our_meals/auth/state_management/update_user_state.dart';
 import 'package:redaux/redaux.dart';
 
-import '../../app_state.dart';
+import '../../app/state/app_state.dart';
+import '../state/user_state.dart';
 
 class SignInWithFirebase extends AsyncAction<AppState> {
+  SignInWithFirebase({required this.idToken, required this.rawNonce});
+
   final String idToken;
-
-  SignInWithFirebase({required this.idToken});
-
-  static final Middleware<AppState> _m = SignInWithFirebaseMiddleware();
+  final String rawNonce;
 
   @override
-  Middleware<AppState>? get middleware => _m;
+  Middleware<AppState> get middleware => _SignInWithFirebaseMiddleware.instance;
 }
 
-class SignInWithFirebaseMiddleware extends Middleware<AppState> {
+class _SignInWithFirebaseMiddleware extends Middleware<AppState> {
   @override
-  void call(store, covariant SignInWithFirebase action) {}
+  void call(store, covariant SignInWithFirebase action) async {
+    UserCredential credential =
+        await service.signInToFirebase(action.idToken, action.rawNonce);
+
+    var user =
+        credential.user ?? (throw 'Firebase Credential has no "user" member');
+    var state = UserState(
+        signedIn: SignedInState.signedIn,
+        displayName: user.displayName,
+        photoUrl: user.photoURL,
+        uid: user.uid);
+
+    store.dispatch(UpdateUserState(state), parent: action);
+  }
+
+  final service = FirebaseAuthService(FirebaseAuth.instance);
+
+  static final instance = _SignInWithFirebaseMiddleware();
 }

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/update_user_state.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/update_user_state.dart
@@ -1,21 +1,21 @@
 import 'package:redaux/redaux.dart';
 
-import '../../app_state.dart';
+import '../../app/state/app_state.dart';
 import '../state/user_state.dart';
 
 class UpdateUserState extends SyncAction<AppState> {
-  final UserState user;
-
   UpdateUserState(this.user);
 
-  static final Reducer<AppState> _r = UpdateUserStateReducer();
+  final UserState user;
 
   @override
-  Reducer<AppState>? get reducer => _r;
+  Reducer<AppState> get reducer => _UpdateUserStateReducer.instance;
 }
 
-class UpdateUserStateReducer extends Reducer<AppState> {
+class _UpdateUserStateReducer extends Reducer<AppState> {
   @override
   AppState call(state, covariant UpdateUserState action) =>
       state.copyWith(user: action.user);
+
+  static final instance = _UpdateUserStateReducer();
 }

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/widgets/sign_in_screen.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/widgets/sign_in_screen.dart
@@ -3,7 +3,7 @@ import 'package:our_meals/auth/state/user_state.dart';
 import 'package:redaux_widgets/redaux_widget.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart' as plugin;
 
-import '../../app_state.dart';
+import '../../app/state/app_state.dart';
 import '../state_management/sign_in_with_apple.dart';
 
 class SignInScreen extends StatelessWidget {

--- a/packages/flutter/apps/experiments/our_meals/lib/main.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:our_meals/home/home_screen.dart';
 import 'package:redaux/redaux.dart';
 import 'package:redaux_widgets/redaux_widget.dart';
 
-import 'app_state.dart';
+import 'app/state/app_state.dart';
 import 'auth/services/firebase_auth_service.dart';
 import 'auth/state/user_state.dart';
 

--- a/packages/flutter/utils/redaux_widgets/lib/widgets/state_stream_builder.dart
+++ b/packages/flutter/utils/redaux_widgets/lib/widgets/state_stream_builder.dart
@@ -6,7 +6,8 @@ import 'package:redaux/redaux.dart' as redaux;
 import '../exceptions/transform_failure_exception.dart';
 import 'store_provider.dart';
 
-class StateStreamBuilder<S extends redaux.State, VM> extends StatelessWidget {
+class StateStreamBuilder<S extends redaux.RootState, VM>
+    extends StatelessWidget {
   final Widget Function(BuildContext context, VM vm) builder;
   final VM Function(S state) transformer;
   final void Function(redaux.Store<S> store)? onInit;
@@ -32,7 +33,8 @@ class StateStreamBuilder<S extends redaux.State, VM> extends StatelessWidget {
   }
 }
 
-class _StateStreamBuilder<S extends redaux.State, VM> extends StatefulWidget {
+class _StateStreamBuilder<S extends redaux.RootState, VM>
+    extends StatefulWidget {
   final redaux.Store<S> store;
   final Widget Function(BuildContext context, VM vm) builder;
   final VM Function(S state) transformer;
@@ -54,7 +56,7 @@ class _StateStreamBuilder<S extends redaux.State, VM> extends StatefulWidget {
   }
 }
 
-class _StateStreamBuilderState<S extends redaux.State, VM>
+class _StateStreamBuilderState<S extends redaux.RootState, VM>
     extends State<_StateStreamBuilder<S, VM>> {
   late Stream<VM> _stream;
   VM? _latestValue;

--- a/packages/flutter/utils/redaux_widgets/lib/widgets/store_provider.dart
+++ b/packages/flutter/utils/redaux_widgets/lib/widgets/store_provider.dart
@@ -3,7 +3,7 @@ import 'package:redaux/redaux.dart' as redaux;
 
 import '../errors/store_provider_not_found_error.dart';
 
-class StoreProvider<S extends redaux.State> extends InheritedWidget {
+class StoreProvider<S extends redaux.RootState> extends InheritedWidget {
   final redaux.Store<S> _store;
 
   const StoreProvider({
@@ -13,7 +13,7 @@ class StoreProvider<S extends redaux.State> extends InheritedWidget {
   })  : _store = store,
         super(key: key, child: child);
 
-  static redaux.Store<S> of<S extends redaux.State>(BuildContext context,
+  static redaux.Store<S> of<S extends redaux.RootState>(BuildContext context,
       {bool listen = true}) {
     final provider = (listen
         ? context.dependOnInheritedWidgetOfExactType<StoreProvider<S>>()


### PR DESCRIPTION
I moved AppState to app/state and updates to extend RootState, which
meant adding a copyWith.

I updated the actions to use the private singleton structure - because
it's a cleaner, more readable approach.

I udpated _SignInWithAppleMiddleware to generate the rawNonce because
the code was there but not connected.