### PR TITLE
new(jst): Add the json_types package

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Three letter acronyms used in commit messages:
 - gau = googleapis_utils
 - gla = gather_link_account
 - gls = gather_link_account_shelf
+- jst = json_types
 - lcr = locator
 - oml = our_meals
 - rdx = redaux

--- a/packages/dart/utils/json_types/.gitignore
+++ b/packages/dart/utils/json_types/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/dart/utils/json_types/CHANGELOG.md
+++ b/packages/dart/utils/json_types/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.1
+
+- Initial version.

--- a/packages/dart/utils/json_types/README.md
+++ b/packages/dart/utils/json_types/README.md
@@ -1,0 +1,45 @@
+# json_types
+
+*Dart utilities for JSON serialisation & deserialisation.*
+
+- [ ] Review for inspiration:
+
+  - [json_utilities | Flutter Package](https://pub.dev/packages/json_utilities)
+  - [leafpetersen/cast: Dart library for type schemas for casting and parsing structured data](https://github.com/leafpetersen/cast)
+    - With this we could provide a declarative method for the complex casting involved in JSON deserialisation
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/packages/dart/utils/json_types/analysis_options.yaml
+++ b/packages/dart/utils/json_types/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/packages/dart/utils/json_types/example/json_types_example.dart
+++ b/packages/dart/utils/json_types/example/json_types_example.dart
@@ -1,0 +1,1 @@
+void main() {}

--- a/packages/dart/utils/json_types/lib/json_types.dart
+++ b/packages/dart/utils/json_types/lib/json_types.dart
@@ -1,0 +1,8 @@
+/// A package whose only purpose is to provide typedefs for apps using JSON data.
+/// This helps to avoid type conflicts between packages that depend on other
+/// packages defining the same type.
+library json_types;
+
+typedef JsonMap = Map<String, dynamic>;
+typedef JsonList = List<dynamic>;
+typedef Json = dynamic;

--- a/packages/dart/utils/json_types/pubspec.yaml
+++ b/packages/dart/utils/json_types/pubspec.yaml
@@ -1,0 +1,13 @@
+name: json_types
+description: Dart utilities for JSON serialisation & deserialisation.
+version: 0.0.1
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+# dependencies:
+#   path: ^1.8.0
+
+dev_dependencies:
+  lints: ^1.0.0
+  test: ^1.16.0

--- a/packages/dart/utils/json_types/test/json_types_test.dart
+++ b/packages/dart/utils/json_types/test/json_types_test.dart
@@ -1,0 +1,14 @@
+import 'package:json_types/json_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests', () {
+    setUp(() {
+      // Additional setup goes here.
+    });
+
+    test('First Test', () {
+      expect(true, true);
+    });
+  });
+}


### PR DESCRIPTION
This is just the refactored json_util package - the next PR has
details on why and how, this PR is to put up a package so
version solving finds a package when it looks in the git path,
which seems to happen when a dependency in turn uses a dependency
with a git path, even when there is an override. The path dep does
seem to eventually be used but we need a package in the github repo
to keep the solver happy.