### PR TITLE
refactor(rdx): use endware for logic after actions

### DIFF
--- a/packages/dart/utils/redaux/lib/redaux.dart
+++ b/packages/dart/utils/redaux/lib/redaux.dart
@@ -4,7 +4,9 @@
 library redaux;
 
 export 'src/action.dart';
+export 'src/endware.dart';
 export 'src/middleware.dart';
+export 'src/models/dispatch_event.dart';
 export 'src/models/error_message.dart';
 export 'src/reducer.dart';
 export 'src/state.dart';

--- a/packages/dart/utils/redaux/lib/src/action.dart
+++ b/packages/dart/utils/redaux/lib/src/action.dart
@@ -5,6 +5,7 @@ import 'reducer.dart';
 import 'state.dart';
 
 abstract class Action {
+  AsyncAction? parent;
   JsonMap toJson({int? parentId});
 }
 

--- a/packages/dart/utils/redaux/lib/src/endware.dart
+++ b/packages/dart/utils/redaux/lib/src/endware.dart
@@ -1,0 +1,19 @@
+import 'action.dart';
+import 'state.dart';
+import 'store.dart';
+
+/// Endware in redaux are like Middleware in redux - each endware is called on
+/// every dispatched action. However, Endwares are always called after the action's
+/// reducer or middleware have been called, hence the 'end' in endware.
+///
+/// When multiple endware are added to the Store, they are called in the order
+/// they were added to the endwares list.
+///
+/// The redaux library is an attempt to make action dispatch easier to reason
+/// about by restricting the relationship b/w actions and middleware/reducers to
+/// a 1:1 relationship but there may be times (eg. during testing & development)
+/// where being able to run logic on every dispatch is advantageous.
+abstract class Endware<S extends RootState> {
+  const Endware();
+  void call(Store<S> store, Action action);
+}

--- a/packages/dart/utils/redaux/lib/src/models/dispatch_event.dart
+++ b/packages/dart/utils/redaux/lib/src/models/dispatch_event.dart
@@ -1,0 +1,7 @@
+import '../../redaux.dart';
+
+class DispatchEvent<T extends RootState> {
+  DispatchEvent(this.action, this.state);
+  final Action action;
+  final T state;
+}

--- a/packages/dart/utils/redaux/lib/src/store.dart
+++ b/packages/dart/utils/redaux/lib/src/store.dart
@@ -1,23 +1,30 @@
 import 'dart:async';
 
-import 'package:json_types/json_types.dart';
 import 'package:redaux/redaux.dart';
 
 /// [stateChangesController] should be broadcast type as UI components will
 /// listen for a time at random intervals and only want the state changes while
 /// they are listening.
+///
+/// Passing in [endWares] allows logic to run on every dispatched [Action], after
+/// the action's reducer or middleware has been called. If the same result can
+/// be achieved using just actions, without adding endware, the 1:1
+/// relationship between Actions and Middleware/Reducers will probably make your
+/// app easier to reason about.
 class Store<S extends RootState> {
   Store({
     required S state,
     StreamController<S>? stateChangesController,
+    List<Endware>? endWares,
   })  : _state = state,
-        _stateChangesController =
-            stateChangesController ?? StreamController<S>.broadcast();
+        _endWares = endWares;
   S _state;
 
-  final StreamController<S> _stateChangesController;
-  final StreamController<JsonMap> _dispatchEventsController =
-      StreamController<JsonMap>.broadcast();
+  final StreamController<S> _stateChangesController =
+      StreamController<S>.broadcast();
+
+  /// Any endWares are called on every dispatched action, see [Endware].
+  final List<Endware>? _endWares;
 
   /// Returns the current state tree of the application.
   /// It is equal to the last value returned by the store's reducer.
@@ -37,7 +44,7 @@ class Store<S extends RootState> {
   ///   each of which inherit from [Action].
   ///
   /// See: https://redux.js.org/api/store#dispatchaction
-  void dispatch(Action action, {AsyncAction<S>? parent}) {
+  void dispatch(Action action) {
     print(action);
 
     // call middleware for async actions
@@ -50,17 +57,7 @@ class Store<S extends RootState> {
       _state = action.reducer.call(_state, action);
     }
 
-    if (const bool.fromEnvironment('REDAUX_DEVTOOLS')) {
-      // Emit json describing the action and (potential) state change on
-      // each action dispatch.
-      _dispatchEventsController.add({
-        'data': {
-          'state': _state.toJson(),
-          'action': action.toJson(parentId: parent?.hashCode)
-        },
-        'type': 'redfire:action_dispatched'
-      });
-    }
+    _endWares?.forEach((fn) => fn.call(this, action));
 
     // put an event in the stream with the new state
     _stateChangesController.add(_state);
@@ -80,11 +77,10 @@ class Store<S extends RootState> {
         ...state.errorMessages
       ];
 
-      // TODO: avoid the need to cast here
+      // TODO: can we avoid the need to cast here?
       _state = state.copyWith(errorMessages: newErrorMessages) as S;
     }
   }
 
   Stream<S> get stateChanges => _stateChangesController.stream;
-  Stream<JsonMap> get dispatchEvents => _dispatchEventsController.stream;
 }

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/bind_auth_state.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/bind_auth_state.dart
@@ -30,7 +30,7 @@ class _BindAuthStateMiddleware extends Middleware<AppState> {
     var service = locate<FirebaseAuthService>();
 
     subscription = service.tapIntoAuthState().listen(
-        (user) => store.dispatch(UpdateUserState(user), parent: action));
+        (user) => store.dispatch(UpdateUserState(user)..parent = action));
   }
 
   StreamSubscription<UserState>? subscription;

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/sign_in_with_apple.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/sign_in_with_apple.dart
@@ -46,9 +46,8 @@ class _SignInWithAppleMiddleware extends Middleware<AppState> {
     var token = credential.identityToken ??
         (throw 'The credential.identityToken variable was null');
 
-    store.dispatch(
-        SignInWithFirebase(idToken: token, rawNonce: generateNonce()),
-        parent: action);
+    store.dispatch(SignInWithFirebase(idToken: token, rawNonce: generateNonce())
+      ..parent = action);
   }
 
   static final instance = _SignInWithAppleMiddleware();

--- a/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/sign_in_with_firebase.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/auth/state_management/sign_in_with_firebase.dart
@@ -39,7 +39,7 @@ class _SignInWithFirebaseMiddleware extends Middleware<AppState> {
         photoUrl: user.photoURL,
         uid: user.uid);
 
-    store.dispatch(UpdateUserState(state), parent: action);
+    store.dispatch(UpdateUserState(state)..parent = action);
   }
 
   final service = FirebaseAuthService(FirebaseAuth.instance);

--- a/packages/flutter/apps/experiments/our_meals/lib/main.dart
+++ b/packages/flutter/apps/experiments/our_meals/lib/main.dart
@@ -15,7 +15,11 @@ import 'app/state/app_state.dart';
 import 'auth/services/firebase_auth_service.dart';
 import 'auth/state/user_state.dart';
 
-final _store = Store<AppState>(state: AppState.initial);
+// TODO: When we put this somewhere (eg. a redafire library) we should add some notes
+// about how already added endWares may mess with results
+// Or even better, how to avoid to problems
+final _endware = EmitDispatchEventsEndware<AppState>();
+final _store = Store<AppState>(state: AppState.initial, endWares: [_endware]);
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -40,7 +44,7 @@ class AuthGate extends StatelessWidget {
           home: SplitView(
         viewMode: SplitViewMode.Horizontal,
         children: [
-          Material(child: RedauxDevToolsScreen(_store.dispatchEvents)),
+          Material(child: RedauxDevToolsScreen(_endware.dispatchEvents)),
           StateStreamBuilder<AppState, SignedInState>(
             transformer: (state) => state.user.signedIn,
             builder: (context, signedIn) {

--- a/packages/flutter/utils/redaux_dev_tools_screen/lib/redaux_dev_tools_screen.dart
+++ b/packages/flutter/utils/redaux_dev_tools_screen/lib/redaux_dev_tools_screen.dart
@@ -8,6 +8,7 @@ import 'package:redaux_widgets/redaux_widget.dart';
 import 'redaux_dev_tools_screen.dart';
 import 'src/views/main_view.dart';
 
+export 'src/endwares/emit_dispatch_events_endware.dart';
 export 'src/state/dev_tools_state.dart';
 
 /// Visualise the data flow of an app by adding a [RedauxDevToolsScreen] widget
@@ -20,10 +21,10 @@ export 'src/state/dev_tools_state.dart';
 ///   app state.
 /// - a 'remove all' event to clear the dispatch events data.
 class RedauxDevToolsScreen extends StatefulWidget {
-  const RedauxDevToolsScreen(this._eventsStream, this._store, {super.key});
+  RedauxDevToolsScreen(this._eventsStream, {super.key});
 
   final Stream<JsonMap>? _eventsStream;
-  final Store<DevToolsState> _store;
+  final Store<DevToolsState> _store = Store(state: DevToolsState.initial);
 
   @override
   State<RedauxDevToolsScreen> createState() => _RedauxDevToolsScreenState();

--- a/packages/flutter/utils/redaux_dev_tools_screen/lib/src/endwares/emit_dispatch_events_endware.dart
+++ b/packages/flutter/utils/redaux_dev_tools_screen/lib/src/endwares/emit_dispatch_events_endware.dart
@@ -1,0 +1,23 @@
+import 'dart:async';
+
+import 'package:json_types/json_types.dart';
+import 'package:redaux/redaux.dart';
+
+class EmitDispatchEventsEndware<T extends RootState> extends Endware<T> {
+  final StreamController<JsonMap> _dispatchEventsController =
+      StreamController<JsonMap>.broadcast();
+  Stream<JsonMap> get dispatchEvents => _dispatchEventsController.stream;
+
+  @override
+  void call(store, Action action) async {
+    // Emit json describing the action and (potential) state change on
+    // each action dispatch.
+    _dispatchEventsController.add({
+      'data': {
+        'state': store.state.toJson(),
+        'action': action.toJson(parentId: action.parent?.hashCode)
+      },
+      'type': 'redfire:action_dispatched'
+    });
+  }
+}

--- a/packages/flutter/utils/redaux_widgets_test_utils/lib/src/record_dispatch_events_endware.dart
+++ b/packages/flutter/utils/redaux_widgets_test_utils/lib/src/record_dispatch_events_endware.dart
@@ -1,0 +1,14 @@
+import 'package:redaux/redaux.dart';
+
+class RecordDispatchEventsEndware<T extends RootState> extends Endware<T> {
+  final List<DispatchEvent> events = [];
+  final Map<Action, T> stateForAction = {};
+
+  @override
+  void call(Store<T> store, Action action) async {
+    events.add(DispatchEvent(action, store.state));
+    stateForAction[action] = store.state;
+  }
+
+  bool includes(Action action) => stateForAction[action] != null;
+}

--- a/packages/flutter/utils/redaux_widgets_test_utils/lib/src/widget_test_harness.dart
+++ b/packages/flutter/utils/redaux_widgets_test_utils/lib/src/widget_test_harness.dart
@@ -17,9 +17,9 @@ class WidgetTestHarness<T extends RootState> {
   final Store<T> _store;
   final Widget _widgetUnderTest;
 
-  WidgetTestHarness({required T initialState, required Widget widgetUnderTest})
+  WidgetTestHarness({required T initialState, required Widget child})
       : _store = Store<T>(state: initialState),
-        _widgetUnderTest = widgetUnderTest;
+        _widgetUnderTest = child;
 
   Widget get widget => StoreProvider<T>(
       store: _store,

--- a/packages/flutter/utils/redaux_widgets_test_utils/lib/src/widget_test_harness.dart
+++ b/packages/flutter/utils/redaux_widgets_test_utils/lib/src/widget_test_harness.dart
@@ -1,7 +1,8 @@
-import 'package:flutter/material.dart';
-import 'package:json_types/json_types.dart';
+import 'package:flutter/material.dart' hide Action;
 import 'package:redaux/redaux.dart';
 import 'package:redaux_widgets/widgets/store_provider.dart';
+
+import 'record_dispatch_events_endware.dart';
 
 /// A test harness for wrapping a widget under test that provides the functionality
 /// that a test may want in order to interact with the widget or check for
@@ -14,12 +15,14 @@ import 'package:redaux_widgets/widgets/store_provider.dart';
 /// The harness exposes Store.dispatchEvents so tests can observe dispatched
 /// actions and the associated state change.
 class WidgetTestHarness<T extends RootState> {
-  final Store<T> _store;
+  late final Store<T> _store;
   final Widget _widgetUnderTest;
+  final dispatchedEvents = RecordDispatchEventsEndware<T>();
 
   WidgetTestHarness({required T initialState, required Widget child})
-      : _store = Store<T>(state: initialState),
-        _widgetUnderTest = child;
+      : _widgetUnderTest = child {
+    _store = Store<T>(state: initialState, endWares: [dispatchedEvents]);
+  }
 
   Widget get widget => StoreProvider<T>(
       store: _store,
@@ -27,5 +30,5 @@ class WidgetTestHarness<T extends RootState> {
 
   T get state => _store.state;
 
-  Stream<JsonMap> get dispatchEvents => _store.dispatchEvents;
+  bool contains(Action action) => dispatchedEvents.includes(action);
 }


### PR DESCRIPTION
I added a class Endware, similar to Middleware, and a List<Endware>
to Store, along with logic to call each endware after each action.

I added a DispatchEvent class, for now just for an endware in the
RedauxWidgetsTestUtils but it will probably also be used instead of
JsonMap for added type safety.

I changed parent to be a property of Action, as otherwise parent
would need to be a parameter of Endware which doesn’t seem right.

I made endwares for use in devtools and for test utils. The classes are
EmitDispatchEventsEndware and RecordDispatchEventsEndware.

I updated our_meals to the new redaux API.