### PR TITLE
refactor(rdx): Rename Action members: leave/arrive

### DIFF
--- a/packages/dart/utils/redaux/lib/redaux.dart
+++ b/packages/dart/utils/redaux/lib/redaux.dart
@@ -5,7 +5,6 @@ library redaux;
 
 export 'src/action.dart';
 export 'src/endware.dart';
-export 'src/middleware.dart';
 export 'src/models/dispatch_event.dart';
 export 'src/models/error_message.dart';
 export 'src/reducer.dart';

--- a/packages/dart/utils/redaux/lib/src/action.dart
+++ b/packages/dart/utils/redaux/lib/src/action.dart
@@ -1,7 +1,6 @@
 import 'package:json_types/json_types.dart';
 
-import 'middleware.dart';
-import 'state.dart';
+import '../redaux.dart';
 
 abstract class Action {
   AsyncAction? parent;
@@ -9,9 +8,9 @@ abstract class Action {
 }
 
 abstract class SyncAction<S extends RootState> extends Action {
-  S reduce(S state);
+  S arrive(S state);
 }
 
 abstract class AsyncAction<S extends RootState> extends Action {
-  Middleware<S> get middleware;
+  Future<void> leave(Store<S> store);
 }

--- a/packages/dart/utils/redaux/lib/src/middleware.dart
+++ b/packages/dart/utils/redaux/lib/src/middleware.dart
@@ -1,8 +1,0 @@
-import 'action.dart';
-import 'state.dart';
-import 'store.dart';
-
-abstract class Middleware<S extends RootState> {
-  const Middleware();
-  void call(Store<S> store, AsyncAction<S> action);
-}


### PR DESCRIPTION
I renamed SyncAction.reduce to "arrive" and AsyncAction now has
"leave". The rename is meant to make it clearer that async actions go
off and do things elsewhere and generally end in a sync action causing a
state change.

I replaced AsyncAction.middleware with a function `leave` of type
Future<void> Function(Store<S>). The type parameter S comes from
the enlcosing class, ie. AsyncAction<S extends RootState>. The
reason is that this gives us the freedom to define the function in the
action declaration, or create a separate singleton then call the
singleton in the leave function... or have any other pattern we like.

In the Store I moved emitting state changes inside the chaeck for
the sync action type as there's no need to emit state changes on async
actions as they cannot change the state.