### PR TITLE
refactor(+): Add auto-parenting for away missions

### DIFF
--- a/packages/dart/utils/astro/lib/astro.dart
+++ b/packages/dart/utils/astro/lib/astro.dart
@@ -1,5 +1,6 @@
 library astro;
 
+export 'src/away_mission_control.dart';
 export 'src/mission.dart';
 export 'src/mission_control.dart';
 export 'src/models/error_message.dart';

--- a/packages/dart/utils/astro/lib/src/away_mission_control.dart
+++ b/packages/dart/utils/astro/lib/src/away_mission_control.dart
@@ -1,0 +1,22 @@
+import '../astro.dart';
+
+/// An [AwayMissionControl] object is created by [MissionControl] on each call
+/// to [AwayMision.flightPlan] for the purpose of allowing land/launch calls
+/// inside `flightPlan` to automatically set the parent.
+///
+/// The call to `launch` & `land` is just passed on to [MissionControl.launch] &
+/// [MissionControl.land], while setting the `parent` member of the mission.
+class AwayMissionControl<T extends RootState> {
+  AwayMissionControl(
+      MissionControl<T> missionControl, AwayMission<T> currentMission)
+      : _missionControl = missionControl,
+        _currentMission = currentMission;
+  final MissionControl<T> _missionControl;
+  final AwayMission<T> _currentMission;
+
+  void land(LandingMission<T> mission) =>
+      _missionControl.land(mission..parent = _currentMission);
+
+  Future<void> launch(AwayMission<T> mission) =>
+      _missionControl.launch(mission..parent = _currentMission);
+}

--- a/packages/dart/utils/astro/lib/src/mission.dart
+++ b/packages/dart/utils/astro/lib/src/mission.dart
@@ -2,17 +2,17 @@ import 'package:json_types/json_types.dart';
 
 import '../astro.dart';
 
-/// All missions must extend either [AwayMission] or [DockingMission], which
+/// All missions must extend either [AwayMission] or [LandingMission], which
 /// both inherit from [Mission].
 abstract class Mission {
   AwayMission? parent;
   JsonMap toJson({int? parentId});
 }
 
-abstract class DockingMission<S extends RootState> extends Mission {
-  S dockingInstructions(S state);
+abstract class LandingMission<T extends RootState> extends Mission {
+  T landingInstructions(T state);
 }
 
-abstract class AwayMission<S extends RootState> extends Mission {
-  Future<void> flightPlan(MissionControl<S> missionControl);
+abstract class AwayMission<T extends RootState> extends Mission {
+  Future<void> flightPlan(AwayMissionControl<T> missionControl);
 }

--- a/packages/dart/utils/astro/lib/src/mission_control.dart
+++ b/packages/dart/utils/astro/lib/src/mission_control.dart
@@ -4,38 +4,38 @@ import 'package:astro/astro.dart';
 
 /// Pass in [systemChecks] to run logic on every [Mission], before
 /// [AwayMission.flightPlan] is called and after
-/// [DockingMission.dockingInstructions] is called.
+/// [LandingMission.landingInstructions] is called.
 ///
 /// Make sure [onStateChangeController] is broadcast type as UI components will
 /// listen for a time at random intervals and only want the state changes while
 /// they are listening.
-class MissionControl<S extends RootState> {
+class MissionControl<T extends RootState> {
   MissionControl({
-    required S state,
-    StreamController<S>? onStateChangeController,
+    required T state,
+    StreamController<T>? onStateChangeController,
     List<SystemCheck>? systemChecks,
   })  : _state = state,
         _systemChecks = systemChecks;
-  S _state;
+  T _state;
 
-  final StreamController<S> _onStateChangeController =
-      StreamController<S>.broadcast();
+  final StreamController<T> _onStateChangeController =
+      StreamController<T>.broadcast();
 
   /// [SystemCheck]s are called on every mission, before [AwayMission.flightPlan]
-  /// is called and after [DockingMission.dockingInstructions] is called.
+  /// is called and after [LandingMission.landingInstructions] is called.
   final List<SystemCheck>? _systemChecks;
 
   /// Returns the current state tree of the application.
-  S get state => _state;
+  T get state => _state;
 
-  /// Landing a [DockingMission] is the only way to upate the state held in
+  /// Landing a [LandingMission] is the only way to upate the state held in
   /// MissionControl, so any data, whether from UI events, network callbacks, or other
   /// sources such as WebSockets needs to eventually be landed (ie. call land on
-  /// [DockingMission] that described the desired state change).
-  void land(DockingMission<S> mission) {
+  /// [LandingMission] that described the desired state change).
+  void land(LandingMission<T> mission) {
     print('land: $mission');
 
-    _state = mission.dockingInstructions(_state);
+    _state = mission.landingInstructions(_state);
 
     // emit the new state for any listeners (eg. StateStreamBuilder widgets)
     _onStateChangeController.add(_state);
@@ -45,8 +45,8 @@ class MissionControl<S extends RootState> {
 
   /// Creation or retrieval of data that is asynchronous must be performed via
   /// an [AwayMission]. If the desired end result is changing the app state,
-  /// the [AwayMission] should land a [DockingMission] when it is complete.
-  void launch(AwayMission<S> mission) async {
+  /// the [AwayMission] should land a [LandingMission] when it is complete.
+  Future<void> launch(AwayMission<T> mission) async {
     print('launch: $mission');
 
     _systemChecks?.forEach((fn) => fn.call(this, mission));
@@ -54,7 +54,7 @@ class MissionControl<S extends RootState> {
     /// We wrap the `launch` calls in a try/catch and if the
     /// call throws, an [ErrorMessage] is added to the AppState.
     try {
-      await mission.flightPlan(this);
+      await mission.flightPlan(AwayMissionControl(this, mission));
     } catch (thrown, trace) {
       print(thrown);
       var newErrorMessages = [
@@ -63,9 +63,9 @@ class MissionControl<S extends RootState> {
       ];
 
       // TODO: can we avoid the need to cast here?
-      _state = state.copyWith(errorMessages: newErrorMessages) as S;
+      _state = state.copyWith(errorMessages: newErrorMessages) as T;
     }
   }
 
-  Stream<S> get onStateChange => _onStateChangeController.stream;
+  Stream<T> get onStateChange => _onStateChangeController.stream;
 }

--- a/packages/dart/utils/astro/lib/src/system_check.dart
+++ b/packages/dart/utils/astro/lib/src/system_check.dart
@@ -3,7 +3,7 @@ import 'mission_control.dart';
 import 'state.dart';
 
 /// [SystemCheck]s in astro are are called for every [Mission] - before
-/// [AwayMission.flightPlan] is called and after [DockingMission.dockingInstructions]
+/// [AwayMission.flightPlan] is called and after [LandingMission.landingInstructions]
 /// is called.
 ///
 /// An [AwayMission] involves calling an async function ([AwayMission.flightPlan]),
@@ -12,7 +12,7 @@ import 'state.dart';
 /// in [MissionControl.launch].
 ///
 /// On the other hand, we always want to know what the new state is *after* a
-/// [DockingMission.dockingInstructions] has run so we run the [SystemCheck]
+/// [LandingMission.landingInstructions] has run so we run the [SystemCheck]
 /// last in [MissionControl.land].
 ///
 /// When multiple system checks are added to [MissionControl], they are called

--- a/packages/flutter/utils/astro_auth/lib/src/state-management/bind_auth_state.dart
+++ b/packages/flutter/utils/astro_auth/lib/src/state-management/bind_auth_state.dart
@@ -12,13 +12,14 @@ StreamSubscription<UserState>? _subscription;
 
 class BindAuthState<T extends RootState> extends AwayMission<T> {
   @override
-  Future<void> flightPlan(MissionControl missionControl) async {
+  Future<void> flightPlan(AwayMissionControl<T> missionControl) async {
     var service = locate<FirebaseAuthService>();
 
     _subscription?.cancel();
 
-    _subscription = service.tapIntoAuthState().listen(
-        (user) => missionControl.land(UpdateUserState<T>(user)..parent = this));
+    _subscription = service
+        .tapIntoAuthState()
+        .listen((user) => missionControl.land(UpdateUserState<T>(user)));
   }
 
   @override

--- a/packages/flutter/utils/astro_auth/lib/src/state-management/sign_in_with_apple.dart
+++ b/packages/flutter/utils/astro_auth/lib/src/state-management/sign_in_with_apple.dart
@@ -19,7 +19,7 @@ class SignInWithApple<T extends RootState> extends AwayMission<T> {
 
   // final nonce = sha256ofString(rawNonce);
   @override
-  Future<void> flightPlan(MissionControl<T> missionControl) async {
+  Future<void> flightPlan(AwayMissionControl<T> missionControl) async {
     final plugin.AuthorizationCredentialAppleID credential =
         await plugin.SignInWithApple.getAppleIDCredential(
       scopes: [
@@ -32,8 +32,7 @@ class SignInWithApple<T extends RootState> extends AwayMission<T> {
         (throw 'The credential.identityToken variable was null');
 
     missionControl.launch(
-        SignInWithFirebase<T>(idToken: token, rawNonce: generateNonce())
-          ..parent = this);
+        SignInWithFirebase<T>(idToken: token, rawNonce: generateNonce()));
   }
 
   @override

--- a/packages/flutter/utils/astro_auth/lib/src/state-management/sign_in_with_firebase.dart
+++ b/packages/flutter/utils/astro_auth/lib/src/state-management/sign_in_with_firebase.dart
@@ -14,7 +14,7 @@ class SignInWithFirebase<T extends RootState> extends AwayMission<T> {
   final String rawNonce;
 
   @override
-  Future<void> flightPlan(MissionControl<T> missionControl) async {
+  Future<void> flightPlan(AwayMissionControl<T> missionControl) async {
     final service = locate<FirebaseAuthService>();
 
     UserCredential credential =
@@ -28,7 +28,7 @@ class SignInWithFirebase<T extends RootState> extends AwayMission<T> {
         photoUrl: user.photoURL,
         uid: user.uid);
 
-    missionControl.land(UpdateUserState<T>(state)..parent = this);
+    missionControl.land(UpdateUserState<T>(state));
   }
 
   @override

--- a/packages/flutter/utils/astro_auth/lib/src/state-management/sign_out.dart
+++ b/packages/flutter/utils/astro_auth/lib/src/state-management/sign_out.dart
@@ -6,7 +6,7 @@ import '../services/firebase_auth_service.dart';
 
 class SignOut<T extends RootState> extends AwayMission<T> {
   @override
-  Future<void> flightPlan(MissionControl<T> missionControl) async {
+  Future<void> flightPlan(AwayMissionControl<T> missionControl) async {
     var service = locate<FirebaseAuthService>();
     await service.signOut();
   }

--- a/packages/flutter/utils/astro_auth/lib/src/state-management/update_user_state.dart
+++ b/packages/flutter/utils/astro_auth/lib/src/state-management/update_user_state.dart
@@ -2,13 +2,13 @@ import 'package:astro/astro.dart';
 
 import '../state/user_state.dart';
 
-class UpdateUserState<T extends RootState> extends DockingMission<T> {
+class UpdateUserState<T extends RootState> extends LandingMission<T> {
   UpdateUserState(this.user);
 
   final UserState user;
 
   @override
-  T dockingInstructions(T state) {
+  T landingInstructions(T state) {
     return (state as dynamic).copyWith(user: user);
   }
 

--- a/packages/flutter/utils/astro_inspector_screen/lib/src/extensions/build_context_extension.dart
+++ b/packages/flutter/utils/astro_inspector_screen/lib/src/extensions/build_context_extension.dart
@@ -1,4 +1,4 @@
-import 'package:astro/astro.dart' show DockingMission, AwayMission;
+import 'package:astro/astro.dart' show LandingMission, AwayMission;
 import 'package:astro_widgets/widgets/mission_control_provider.dart';
 import 'package:flutter/widgets.dart' show BuildContext;
 
@@ -8,6 +8,6 @@ import '../state/inspector_state.dart';
 extension BuildContextExtension on BuildContext {
   void launch(AwayMission<InspectorState> mission) =>
       MissionControlProvider.of<InspectorState>(this).launch(mission);
-  void land(DockingMission<InspectorState> mission) =>
+  void land(LandingMission<InspectorState> mission) =>
       MissionControlProvider.of<InspectorState>(this).land(mission);
 }

--- a/packages/flutter/utils/astro_inspector_screen/lib/src/state-management/add_mission_event.dart
+++ b/packages/flutter/utils/astro_inspector_screen/lib/src/state-management/add_mission_event.dart
@@ -8,7 +8,7 @@ import 'select_mission.dart';
 /// Also sets the selected index to the new mission event.
 /// The incoming json is assumed to have the form:
 /// `{ mission: {id_ : <id>, ... }`
-class AddMissionEvent extends DockingMission<InspectorState> {
+class AddMissionEvent extends LandingMission<InspectorState> {
   AddMissionEvent(this._eventJson);
 
   final JsonMap _eventJson;
@@ -18,7 +18,7 @@ class AddMissionEvent extends DockingMission<InspectorState> {
   JsonMap get eventJson => JsonMap.unmodifiable(_eventJson);
 
   @override
-  InspectorState dockingInstructions(state) {
+  InspectorState landingInstructions(state) {
     var newState = state.copyWith(
         missionEvents: [...state.missionEvents, eventJson],
         selectedIndex: state.missionEvents.length,

--- a/packages/flutter/utils/astro_inspector_screen/lib/src/state-management/remove_mission_events.dart
+++ b/packages/flutter/utils/astro_inspector_screen/lib/src/state-management/remove_mission_events.dart
@@ -2,9 +2,9 @@ import 'package:astro/astro.dart';
 
 import '../state/inspector_state.dart';
 
-class RemoveMissionEvents extends DockingMission<InspectorState> {
+class RemoveMissionEvents extends LandingMission<InspectorState> {
   @override
-  InspectorState dockingInstructions(state) =>
+  InspectorState landingInstructions(state) =>
       state.copyWith(selectedIndex: null);
 
   @override

--- a/packages/flutter/utils/astro_inspector_screen/lib/src/state-management/select_mission.dart
+++ b/packages/flutter/utils/astro_inspector_screen/lib/src/state-management/select_mission.dart
@@ -3,7 +3,7 @@ import 'package:astro/astro.dart';
 import '../enums/lineage_shape.dart';
 import '../state/inspector_state.dart';
 
-class SelectMission extends DockingMission<InspectorState> {
+class SelectMission extends LandingMission<InspectorState> {
   final int _index;
 
   SelectMission(this._index);
@@ -12,7 +12,7 @@ class SelectMission extends DockingMission<InspectorState> {
 
   /// Select a list item and also identify the appropriate lineage to be drawn.
   @override
-  InspectorState dockingInstructions(state) =>
+  InspectorState landingInstructions(state) =>
       updateSelectedAndLineage(state, index);
 
   @override

--- a/packages/flutter/utils/astro_inspector_screen/lib/src/utils/on_mission_start_system_check.dart
+++ b/packages/flutter/utils/astro_inspector_screen/lib/src/utils/on_mission_start_system_check.dart
@@ -9,7 +9,7 @@ class OnMissionStartSystemCheck<T extends RootState> extends SystemCheck<T> {
   Stream<JsonMap> get stream => _controller.stream;
 
   @override
-  void call(missionControl, Mission mission) async {
+  void call(MissionControl missionControl, Mission mission) async {
     // Emit json describing the mission and (potential) state change on
     // each mission.
     _controller.add({

--- a/packages/flutter/utils/astro_inspector_screen/test/models/test_away_mission.dart
+++ b/packages/flutter/utils/astro_inspector_screen/test/models/test_away_mission.dart
@@ -4,7 +4,7 @@ import 'package:astro_inspector_screen/astro_inspector_screen.dart';
 class TestAwayMission extends AwayMission<InspectorState> {
   @override
   Future<void> flightPlan(
-      MissionControl<InspectorState> missionControl) async {}
+      AwayMissionControl<InspectorState> missionControl) async {}
 
   @override
   toJson({int? parentId}) => {

--- a/packages/flutter/utils/astro_widgets_test_utils/lib/src/widget_test_harness.dart
+++ b/packages/flutter/utils/astro_widgets_test_utils/lib/src/widget_test_harness.dart
@@ -37,5 +37,5 @@ class WidgetTestHarness<T extends RootState> {
   List<Mission> get recordedMissions => _recorded.missions;
 
   void launch(AwayMission<T> mission) => _missionControl.launch(mission);
-  void land(DockingMission<T> mission) => _missionControl.land(mission);
+  void land(LandingMission<T> mission) => _missionControl.land(mission);
 }


### PR DESCRIPTION
I added AwayMissionControl which decorates MissionControl with a parent
mission. When MissionControl calls AwayMission.flightPlan it creates and
passes in an AwayMissionControl object with launch and land functions
that set the mission’s parent before calling MissionControl's
land/launch.

I renamed dockingMission to landingMission as we have landed (ay!) on
LandingMission/AwayMission for the naming.

I also replaced the type parameter S with T for conistency, as we were
using both in different places.