### PR TITLE
new(aei): Add astro_error_handling_interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Three letter acronyms used in commit messages:
 
 - acf - authorization code flow
 - aau = astro_auth
+- aeh = astro_error_handling
+- aei = astro_error_handling_interface
 - ast = astro
 - ais = astro_inspector_screen
 - atu = astro_test_utils

--- a/packages/dart/interfaces/astro_error_handling_interface/.gitignore
+++ b/packages/dart/interfaces/astro_error_handling_interface/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/dart/interfaces/astro_error_handling_interface/CHANGELOG.md
+++ b/packages/dart/interfaces/astro_error_handling_interface/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.1
+
+- Initial version.

--- a/packages/dart/interfaces/astro_error_handling_interface/README.md
+++ b/packages/dart/interfaces/astro_error_handling_interface/README.md
@@ -1,0 +1,27 @@
+# astro_error_handling_interface
+
+*An interface for astro error handling plugins to implement.*
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder.
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to
+contribute to the package, how to file issues, what response they can expect
+from the package authors, and more.

--- a/packages/dart/interfaces/astro_error_handling_interface/analysis_options.yaml
+++ b/packages/dart/interfaces/astro_error_handling_interface/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/packages/dart/interfaces/astro_error_handling_interface/example/astro_error_handling_interface_example.dart
+++ b/packages/dart/interfaces/astro_error_handling_interface/example/astro_error_handling_interface_example.dart
@@ -1,0 +1,3 @@
+void main() {
+  print('awesome: isAwesome');
+}

--- a/packages/dart/interfaces/astro_error_handling_interface/lib/astro_error_handling_interface.dart
+++ b/packages/dart/interfaces/astro_error_handling_interface/lib/astro_error_handling_interface.dart
@@ -1,0 +1,1 @@
+library astro_error_handling_interface;

--- a/packages/dart/interfaces/astro_error_handling_interface/lib/src/astro_error_handling.dart
+++ b/packages/dart/interfaces/astro_error_handling_interface/lib/src/astro_error_handling.dart
@@ -1,0 +1,5 @@
+import 'error_message_base.dart';
+
+abstract class AstroErrorHandling {
+  abstract final List<ErrorMessageBase> errorMessages;
+}

--- a/packages/dart/interfaces/astro_error_handling_interface/lib/src/error_message_base.dart
+++ b/packages/dart/interfaces/astro_error_handling_interface/lib/src/error_message_base.dart
@@ -1,0 +1,6 @@
+/// Class for carrying basic error information for display to the user.
+abstract class ErrorMessageBase {
+  ErrorMessageBase({required this.message, required this.trace});
+  final String message;
+  final String trace;
+}

--- a/packages/dart/interfaces/astro_error_handling_interface/pubspec.yaml
+++ b/packages/dart/interfaces/astro_error_handling_interface/pubspec.yaml
@@ -1,0 +1,13 @@
+name: astro_error_handling_interface
+description: An interface for astro error handling plugins to implement.
+version: 0.0.1
+
+environment:
+  sdk: '>=2.18.1 <3.0.0'
+
+# dependencies:
+#   path: ^1.8.0
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.16.0

--- a/packages/dart/interfaces/astro_error_handling_interface/test/astro_error_handling_interface_test.dart
+++ b/packages/dart/interfaces/astro_error_handling_interface/test/astro_error_handling_interface_test.dart
@@ -1,0 +1,11 @@
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests', () {
+    setUp(() {
+      // Additional setup goes here.
+    });
+
+    test('First Test', () {});
+  });
+}


### PR DESCRIPTION
This is a dart package that defines abstract classes to act as
interfaces so anyone can create their own astro error handling plugin.

We need a separate interface in this case as the error handling is
somewhat unavoidably baked into the code of the astro package.

So astro will depend on the interface, as will my plugin
'astro_error_handling' as will anyone that wants to make their own
plugin.