### PR TITLE
new(asi): Add astro_state_interface package

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Three letter acronyms used in commit messages:
 - aeh = astro_error_handling
 - aei = astro_error_handling_interface
 - ast = astro
+- asi = astro_state_interface
 - ais = astro_inspector_screen
 - atu = astro_test_utils
 - avs = Adventuverse (project)

--- a/packages/dart/interfaces/astro_state_interface/.gitignore
+++ b/packages/dart/interfaces/astro_state_interface/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/dart/interfaces/astro_state_interface/CHANGELOG.md
+++ b/packages/dart/interfaces/astro_state_interface/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/packages/dart/interfaces/astro_state_interface/README.md
+++ b/packages/dart/interfaces/astro_state_interface/README.md
@@ -1,0 +1,27 @@
+# astro_state_interface
+
+*Immutable state for the astro package.*
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder.
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to
+contribute to the package, how to file issues, what response they can expect
+from the package authors, and more.

--- a/packages/dart/interfaces/astro_state_interface/analysis_options.yaml
+++ b/packages/dart/interfaces/astro_state_interface/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/packages/dart/interfaces/astro_state_interface/example/astro_state_example.dart
+++ b/packages/dart/interfaces/astro_state_interface/example/astro_state_example.dart
@@ -1,0 +1,3 @@
+void main() {
+  print('awesome: isAwesome');
+}

--- a/packages/dart/interfaces/astro_state_interface/lib/astro_state_interface.dart
+++ b/packages/dart/interfaces/astro_state_interface/lib/astro_state_interface.dart
@@ -1,0 +1,10 @@
+library astro_state_interface;
+
+import 'package:json_types/json_types.dart';
+import 'package:meta/meta.dart';
+
+@immutable
+mixin AstroState {
+  AstroState copyWith();
+  Json toJson();
+}

--- a/packages/dart/interfaces/astro_state_interface/pubspec.yaml
+++ b/packages/dart/interfaces/astro_state_interface/pubspec.yaml
@@ -1,0 +1,18 @@
+name: astro_state_interface
+description: Immutable state for the astro package.
+version: 0.0.1
+publish_to: none
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  meta: ^1.8.0
+  json_types:
+    git:
+      url: https://github.com/enspyrco/monorepo.git
+      path: packages/dart/utils/json_types
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.16.0

--- a/packages/dart/interfaces/astro_state_interface/pubspec_overrides.yaml
+++ b/packages/dart/interfaces/astro_state_interface/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  json_types:
+    path: ../../utils/json_types

--- a/packages/dart/interfaces/astro_state_interface/test/astro_state_interface_test.dart
+++ b/packages/dart/interfaces/astro_state_interface/test/astro_state_interface_test.dart
@@ -1,0 +1,13 @@
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests', () {
+    setUp(() {
+      // Additional setup goes here.
+    });
+
+    test('First Test', () {
+      expect(true, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
I added an interface package (astro_state_interface) so that plugin
packages can use the AstroState mixin without having to depend on
the astro package (which creates a circular dependency).