### PR TITLE
chore(aei): Update with BaseErrorHandlers mixin

### DIFF
--- a/packages/dart/interfaces/astro_error_handling_interface/lib/astro_error_handling_interface.dart
+++ b/packages/dart/interfaces/astro_error_handling_interface/lib/astro_error_handling_interface.dart
@@ -1,1 +1,8 @@
 library astro_error_handling_interface;
+
+import 'package:astro_state_interface/astro_state_interface.dart';
+
+mixin BaseErrorHandlers {
+  AstroState handleLaunchError(AstroState state);
+  AstroState handleLandingError(AstroState state);
+}

--- a/packages/dart/interfaces/astro_error_handling_interface/lib/src/astro_error_handling.dart
+++ b/packages/dart/interfaces/astro_error_handling_interface/lib/src/astro_error_handling.dart
@@ -1,5 +1,0 @@
-import 'error_message_base.dart';
-
-abstract class AstroErrorHandling {
-  abstract final List<ErrorMessageBase> errorMessages;
-}

--- a/packages/dart/interfaces/astro_error_handling_interface/lib/src/error_message_base.dart
+++ b/packages/dart/interfaces/astro_error_handling_interface/lib/src/error_message_base.dart
@@ -1,6 +1,0 @@
-/// Class for carrying basic error information for display to the user.
-abstract class ErrorMessageBase {
-  ErrorMessageBase({required this.message, required this.trace});
-  final String message;
-  final String trace;
-}

--- a/packages/dart/interfaces/astro_error_handling_interface/pubspec.yaml
+++ b/packages/dart/interfaces/astro_error_handling_interface/pubspec.yaml
@@ -1,12 +1,16 @@
 name: astro_error_handling_interface
 description: An interface for astro error handling plugins to implement.
 version: 0.0.1
+publish_to: none
 
 environment:
-  sdk: '>=2.18.1 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
-# dependencies:
-#   path: ^1.8.0
+dependencies:
+  astro_state_interface:
+    git:
+      url: https://github.com/enspyrco/monorepo.git
+      path: packages/dart/interfaces/astro_state_interface
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/dart/interfaces/astro_error_handling_interface/pubspec_overrides.yaml
+++ b/packages/dart/interfaces/astro_error_handling_interface/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  astro_state_interface:
+    path: ../astro_state_interface


### PR DESCRIPTION
I added a mixin that error handling plugins will use to
create a class that can be added to the MissionControl.

Currently the analyzer is happy but we get compiler errors
suggesting the interface types aren't available. I'm wondering
if it's due to a problem with the pubspec_overrides so this is also
a test to see if having the correct types in the main branch will fix
the problem.