### PR TITLE
Update BaseErrorHandlers to take a type parameter

### DIFF
--- a/packages/dart/interfaces/astro_error_handling_interface/lib/astro_error_handling_interface.dart
+++ b/packages/dart/interfaces/astro_error_handling_interface/lib/astro_error_handling_interface.dart
@@ -2,7 +2,15 @@ library astro_error_handling_interface;
 
 import 'package:astro_state_interface/astro_state_interface.dart';
 
-mixin BaseErrorHandlers {
-  AstroState handleLaunchError(AstroState state);
-  AstroState handleLandingError(AstroState state);
+mixin BaseErrorHandlers<S extends AstroState> {
+  AstroState handleLaunchError(
+      {required Object thrown,
+      required StackTrace trace,
+      required dynamic mission,
+      required S state});
+  AstroState handleLandingError(
+      {required Object thrown,
+      required StackTrace trace,
+      required dynamic mission,
+      required S state});
 }


### PR DESCRIPTION
I also updated the handleLaunchError & handleLandingError functions to
take useful parameters for handling errors.