### PR TITLE
new(alr): Add astro_locator

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Three letter acronyms used in commit messages:
 - anv = astro_navigation
 - ast = astro
 - asi = astro_state_interface
+- alr = astro_locator
 - ais = astro_inspector_screen
 - atu = astro_test_utils
 - avs = Adventuverse (project)

--- a/packages/dart/utils/astro_locator/.gitignore
+++ b/packages/dart/utils/astro_locator/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/dart/utils/astro_locator/CHANGELOG.md
+++ b/packages/dart/utils/astro_locator/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial version.

--- a/packages/dart/utils/astro_locator/README.md
+++ b/packages/dart/utils/astro_locator/README.md
@@ -1,0 +1,27 @@
+# astro_locator
+
+*A simple service locator for use with Astro.*
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/packages/dart/utils/astro_locator/analysis_options.yaml
+++ b/packages/dart/utils/astro_locator/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/packages/dart/utils/astro_locator/example/astro_locator_example.dart
+++ b/packages/dart/utils/astro_locator/example/astro_locator_example.dart
@@ -1,0 +1,3 @@
+void main() {
+  print('awesome: isAwesome');
+}

--- a/packages/dart/utils/astro_locator/lib/astro_locator.dart
+++ b/packages/dart/utils/astro_locator/lib/astro_locator.dart
@@ -1,0 +1,49 @@
+library astro_locator;
+
+/// Current Limitations
+/// - Only one object of a certain type can be added/located
+/// - The Locator is a currently singleton, but the object it creates allows
+///   the service locator pattern.
+
+/// add a service:
+///   `Locator.add<ServiceType>(Service());`
+/// locate a service:
+///   `var service = locate<ServiceType>();`
+
+/// A global variable for more readable calls eg. locate<Type>();
+final locate = Locator.instance;
+
+/// The singleton Locator class
+class Locator {
+  static final Locator _instance = Locator();
+  static Locator get instance => _instance;
+
+  static final Map<Type, Object> _objectOfType = {};
+
+  T call<T>() {
+    var object = _objectOfType[T] as T?;
+
+    if (object == null) {
+      throw 'You attempted to locate an object before it has been added.\n'
+          'Make sure to call the `add` function before calling the Locator object.';
+    }
+
+    return object;
+  }
+
+  /// Creates an entry in the _objectOfType map.
+  /// The object can now be located witout error.
+  ///
+  /// Setting `overwrite: false` will throw if an object has already been added
+  /// for the given type.
+  static void add<T>(Object object, {bool overwrite = true}) {
+    if (!overwrite) {
+      if (_objectOfType[T] != null) {
+        throw 'You attempted to add an object with a type that has already been added.\n'
+            'Consider using a collection of the given type.';
+      }
+    }
+
+    _objectOfType[T] = object;
+  }
+}

--- a/packages/dart/utils/astro_locator/pubspec.yaml
+++ b/packages/dart/utils/astro_locator/pubspec.yaml
@@ -1,0 +1,14 @@
+name: astro_locator
+description: A simple service locator for use with Astro.
+version: 0.0.1
+publish_to: none
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+# dependencies:
+#   path: ^1.8.0
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.16.0

--- a/packages/dart/utils/astro_locator/test/astro_locator_test.dart
+++ b/packages/dart/utils/astro_locator/test/astro_locator_test.dart
@@ -1,0 +1,13 @@
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests', () {
+    setUp(() {
+      // Additional setup goes here.
+    });
+
+    test('First Test', () {
+      expect(true, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
I created a new Dart package named astro_locator and copied the contents
the locator package. I want to have a general service locator package
and one specifically for astro. They are the same now but will most
likely diverge at some point.