### PR TITLE
fix(*): download dart deps before compile cli app

### DIFF
--- a/.github/workflows/compile_identify_affected_packages.yaml
+++ b/.github/workflows/compile_identify_affected_packages.yaml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           cd packages/dart/cli-apps/ci-tools/identify_affected_packages
+          dart pub get
           dart compile exe bin/identify_affected_packages.dart -o ~/.github/scripts/identify_affected_packages
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/packages/dart/cli-apps/ci-tools/identify_affected_packages/pubspec.lock
+++ b/packages/dart/cli-apps/ci-tools/identify_affected_packages/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.0"
   glob:
     dependency: transitive
     description:
@@ -119,7 +119,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:


### PR DESCRIPTION
In compile_identify_affected_packages.yaml we were not calling
'dart pub get' before compiling identify_affected_packages. Now fixed.