### PR TITLE
fix(*): use $GITHUB_WORKSPACE in path

### DIFF
--- a/.github/workflows/compile_identify_affected_packages.yaml
+++ b/.github/workflows/compile_identify_affected_packages.yaml
@@ -17,7 +17,7 @@ jobs:
       - run: |
           cd packages/dart/cli-apps/ci-tools/identify_affected_packages
           dart pub get
-          dart compile exe bin/identify_affected_packages.dart -o ~/.github/scripts/identify_affected_packages
+          dart compile exe bin/identify_affected_packages.dart -o $GITHUB_WORKSPACE/.github/scripts/identify_affected_packages
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .


### PR DESCRIPTION
In compile_identify_affected_packages.yaml we were using ~ iin the path,
pointing to a location that doesn't exist in the CI environment. Now we
use $GITHUB_WORKSPACE to keep the peace.