### PR TITLE
chore(enl): Rename redfire_lints to enspyr_lints

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - run: echo ${{ steps.read-matrix.outputs.json }}
   
   run_tests:
-    # if: needs.setup_matrix.outputs.matrix_json.include[0] != null # only run if matrix is non-empty
+    if: needs.setup_matrix.outputs.matrix_json.include[0] != null # only run if matrix is non-empty
     name: Run Tests
     needs: setup_matrix
     runs-on: ubuntu-latest

--- a/packages/flutter/utils/enspyr_lints/.gitignore
+++ b/packages/flutter/utils/enspyr_lints/.gitignore
@@ -1,0 +1,29 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.packages
+build/

--- a/packages/flutter/utils/enspyr_lints/.metadata
+++ b/packages/flutter/utils/enspyr_lints/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: 8f1f9c10f04b8f106d78275e93ceead8ea837d8b
+  channel: beta
+
+project_type: package

--- a/packages/flutter/utils/enspyr_lints/CHANGELOG.md
+++ b/packages/flutter/utils/enspyr_lints/CHANGELOG.md
@@ -1,5 +1,10 @@
-# CHANGELOG
+# Changelog
+
+## 1.0.1
+
+* Renamed to enspyr_lints, updated to futter_lints:2.0.1 & new syntax
+  for strong mode in static analysis
 
 ## 1.0.0
 
-* Moved lints out of enspyr into separate package enspyr_lints.
+* Moved lints out of redfire into separate package redfire_lints.

--- a/packages/flutter/utils/enspyr_lints/CHANGELOG.md
+++ b/packages/flutter/utils/enspyr_lints/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## 1.0.1
 
+Oct 28 '22
+
 * Renamed to enspyr_lints, updated to futter_lints:2.0.1 & new syntax
   for strong mode in static analysis
 
 ## 1.0.0
+
+Mid '21
 
 * Moved lints out of redfire into separate package redfire_lints.

--- a/packages/flutter/utils/enspyr_lints/CHANGELOG.md
+++ b/packages/flutter/utils/enspyr_lints/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 1.0.0
+
+* Moved lints out of enspyr into separate package enspyr_lints.

--- a/packages/flutter/utils/enspyr_lints/README.md
+++ b/packages/flutter/utils/enspyr_lints/README.md
@@ -1,0 +1,53 @@
+# enspyr_lints
+
+This package contains a recommended set of lints for Enspyr apps.
+
+The enspyr lints are a selected set added to the set of lints from [flutter_lints], along with:
+
+- [stricter type checks] enabled
+- [custom analysis rules] added to ignore generated files
+
+**Background info from [flutter_lints]:**
+
+Lints are surfaced by the [dart analyzer], which statically checks dart code.
+[Dart-enabled IDEs] typically present the issues identified by the analyzer in
+their UI. Alternatively, the analyzer can be invoked manually by running
+`flutter analyze`.
+
+More information:
+
+- [package:lints]
+- [linter rules] (docs) & [lints] (generated list)
+
+## Usage
+
+### pubspec
+
+In `pubspec.yaml` replace
+
+```yaml
+flutter_lints: ^1.0.0 
+```
+
+with
+
+```yaml
+enspyr_lints: ^1.0.0 
+```
+
+### analysis_options
+
+Replace the contents of `analysis_options.yaml` file with:
+
+```yaml
+include: package:enspyr_lints/flutter.yaml
+```
+
+[flutter_lints]: https://github.com/flutter/packages/tree/master/packages/flutter_lints
+[stricter type checks]: https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks
+[custom analysis rules]: https://dart.dev/guides/language/analysis-options#customizing-analysis-rules
+[dart analyzer]: https://dart.dev/guides/language/analysis-options
+[Dart-enabled IDEs]: https://dart.dev/tools#ides-and-editors
+[package:lints]: https://pub.dev/packages/lints
+[linter rules]: https://dart.dev/tools/linter-rules
+[lints]: https://dart-lang.github.io/linter/lints/

--- a/packages/flutter/utils/enspyr_lints/lib/flutter.yaml
+++ b/packages/flutter/utils/enspyr_lints/lib/flutter.yaml
@@ -1,0 +1,35 @@
+# Recommended lints for Flutter apps, packages, and plugins.
+
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude:
+    - build/**
+    - lib/*.g.dart
+    - lib/*.freezed.dart
+    - lib/**/*.g.dart
+    - lib/**/*.freezed.dart
+    - lib/**/*.mocks.dart
+    - test/**/*.g.dart
+    - test/**/*.freezed.dart
+    - test/**/*.mocks.dart
+  language:
+    strict-casts: true
+    strict-raw-types: true
+
+linter:
+  rules:
+    - prefer_relative_imports
+
+# prefer_relative_imports
+# 
+# reason:
+#  - There are reasons for both package and relative imports
+#  - Effective Dart says relative: https://dart.dev/guides/language/effective-dart/usage#prefer-relative-import-paths
+#
+#
+# avoid_relative_lib_imports
+# reason:
+#  - Effective Dart says so: https://dart.dev/guides/language/effective-dart/usage#dont-allow-an-import-path-to-reach-into-or-out-of-lib
+#
+#

--- a/packages/flutter/utils/enspyr_lints/pubspec.yaml
+++ b/packages/flutter/utils/enspyr_lints/pubspec.yaml
@@ -1,0 +1,11 @@
+name: enspyr_lints
+description: Recommended lints for Enspyr apps.
+repository: https://github.com/enspyrco/monorepo/tree/main/packages/enspyr_lints
+issue_tracker: https://github.com/enspyrco/monorepo/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+enspyr_lints%22
+version: 1.0.0
+
+environment:
+  sdk: ">=2.18.0 <3.0.0"
+
+dependencies:
+  flutter_lints: ^2.0.1


### PR DESCRIPTION
The rename is partly because redfire is going away and because it
makes more sense to have an org-wide set of lints rather than per-package.

I also did some updating while I was there, now using flutter_lints v2
and the newer version of strong mode for static analysis