### PR TITLE
Add final CI job that depends on matrix job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,7 @@ jobs:
       - run: echo ${{ steps.read-matrix.outputs.json }}
   
   run-tests:
+    if: needs.setup-matrix.outputs.matrix_json.include[0] != null # only run if matrix is non-empty
     needs: setup-matrix
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   setup-matrix:
-    # name: Setup Matrix
     runs-on: ubuntu-latest
     outputs:
       matrix_json: ${{ steps.read-matrix.outputs.json }}
@@ -23,8 +22,6 @@ jobs:
       - run: echo ${{ steps.read-matrix.outputs.json }}
   
   run-tests:
-    # if: needs.setup-matrix.outputs.matrix_json.include[0] != null # only run if matrix is non-empty
-    # name: Run Tests
     needs: setup-matrix
     runs-on: ubuntu-latest
     strategy:
@@ -65,3 +62,9 @@ jobs:
         run: flutter pub run build_runner build
       
       - run: flutter test
+
+  tests-complete:
+    runs-on: ubuntu-latest
+    needs: run-tests
+    steps:
+      - run: echo Done!

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -70,7 +70,7 @@ jobs:
     needs: run-tests
     steps:
       - run: |
-          result="${{ needs.build.result }}"
+          result="${{ needs.build.run-tests }}"
           echo $result
           if [[ $result == "success" || $result == "skipped" ]]; then
             exit 0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -70,7 +70,7 @@ jobs:
     needs: run-tests
     steps:
       - run: |
-          result="${{ needs.build.run-tests }}"
+          result="${{ needs.run-tests.result }}"
           echo $result
           if [[ $result == "success" || $result == "skipped" ]]; then
             exit 0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,8 +64,16 @@ jobs:
       
       - run: flutter test
 
-  tests-complete:
+  tests-result:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: run-tests
     steps:
-      - run: echo Done!
+      - run: |
+          result="${{ needs.build.result }}"
+          echo $result
+          if [[ $result == "success" || $result == "skipped" ]]; then
+            exit 0
+          else
+            exit 1
+          fi


### PR DESCRIPTION
So we can add a status check on the final job meaning CI will only go
green when all tests have run successfully (or no test jobs were run due
to no affected packages). The status check on the matrix job has been
problematic now that the matrix is dynamic.