### PR TITLE
feat(aeh): Add configurable error reports

### DIFF
--- a/packages/flutter/utils/astro_error_handling/lib/astro_error_handling.dart
+++ b/packages/flutter/utils/astro_error_handling/lib/astro_error_handling.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'src/routes/error_report/error_report_page_state.dart';
 import 'src/routes/error_report/error_report_screen.dart';
 
+export 'src/exceptions/astro_exception.dart';
 export 'src/implementations/error_handlers_implementation/default_error_handlers.dart';
 export 'src/missions/create_error_report.dart';
 export 'src/routes/error_report/error_report_page.dart';

--- a/packages/flutter/utils/astro_error_handling/lib/src/exceptions/astro_exception.dart
+++ b/packages/flutter/utils/astro_error_handling/lib/src/exceptions/astro_exception.dart
@@ -1,0 +1,25 @@
+import 'package:astro_types/error_handling_types.dart';
+
+/// [AstroException] has members for message and reportSettings so
+/// that anyone can easily create an exception that configures the resulting
+/// error message in different ways.
+class AstroException implements Exception {
+  const AstroException(
+      {this.reportSettings = ErrorReportSettings.fullReport,
+      required this.message});
+
+  final String message;
+  final ErrorReportSettings reportSettings;
+}
+
+// AstroInfoException is set to configure the displayed error message to just
+// display the message with no stack trace or mission details. This is
+// intended to be used for things like incorrect (but expected) user input
+// where we want to give the user info about what happened but not details
+// like the stack trace that look like a crash.
+class AstroInfoException extends AstroException {
+  const AstroInfoException({required super.message});
+
+  @override
+  ErrorReportSettings get reportSettings => ErrorReportSettings.infoMessage;
+}

--- a/packages/flutter/utils/astro_error_handling/lib/src/implementations/error_handlers_implementation/default_error_handlers.dart
+++ b/packages/flutter/utils/astro_error_handling/lib/src/implementations/error_handlers_implementation/default_error_handlers.dart
@@ -11,21 +11,23 @@ class DefaultErrorHandlers<S extends AstroState> implements ErrorHandlers<S> {
   void handleLandingError({
     required Object thrown,
     required StackTrace trace,
+    required ErrorReportSettings reportSettings,
     required LandingMission mission,
     required MissionControl missionControl,
   }) {
     missionControl.land(CreateErrorReport<S>(thrown, trace,
-        details: {'While landing': '$mission'}));
+        settings: reportSettings, details: {'While landing': '$mission'}));
   }
 
   @override
   void handleLaunchError({
     required Object thrown,
     required StackTrace trace,
+    required ErrorReportSettings reportSettings,
     required AwayMission mission,
     required MissionControl missionControl,
   }) {
     missionControl.land(CreateErrorReport<S>(thrown, trace,
-        details: {'While launching': '$mission'}));
+        settings: reportSettings, details: {'While launching': '$mission'}));
   }
 }

--- a/packages/flutter/utils/astro_error_handling/lib/src/missions/create_error_report.dart
+++ b/packages/flutter/utils/astro_error_handling/lib/src/missions/create_error_report.dart
@@ -6,22 +6,30 @@ import 'package:astro_types/state_types.dart';
 import '../../astro_error_handling.dart';
 
 class CreateErrorReport<S extends AstroState> extends LandingMission<S> {
-  const CreateErrorReport(this.error, this.trace, {this.details});
+  const CreateErrorReport(this.error, this.trace,
+      {this.settings = ErrorReportSettings.fullReport, this.details});
 
   final Object error;
   final StackTrace trace;
+  final ErrorReportSettings settings;
   final Map<String, String>? details;
 
   @override
   S landingInstructions(S state) {
-    String message = 'An error occurred:\n\n$error\n\n';
-    if (details != null) {
-      message += '${[
+    String message =
+        (error is AstroException && settings == ErrorReportSettings.infoMessage)
+            ? (error as AstroException).message
+            : '{$error}';
+    if (details != null && settings != ErrorReportSettings.infoMessage) {
+      message += [
         for (var entry in details!.entries) '${entry.key}: ${entry.value}'
-      ].join('\n')}\n\n';
+      ].join('\n');
     }
-    message += 'The stacktrace is:\n\n$trace';
-    var report = DefaultErrorReport(message: message);
+    var report = DefaultErrorReport(
+      message: message,
+      trace: '$trace',
+      settings: settings,
+    );
     // we don't have the AppState type here so we cast to dynamic & use dynamic invocation
     final dynamicState = state as dynamic;
     List<DefaultErrorReport> newReports = [

--- a/packages/flutter/utils/astro_error_handling/lib/src/routes/error_report/error_report_screen.dart
+++ b/packages/flutter/utils/astro_error_handling/lib/src/routes/error_report/error_report_screen.dart
@@ -14,9 +14,14 @@ class ErrorReportScreen<T extends AstroState> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    String message = report.message;
+    if (report.trace != null && report.settings.showStackTrace) {
+      message += '\n\nThe stacktrace is:\n\n${report.trace}';
+    }
+
     return AlertDialog(
-      title: const Text('Whoops'),
-      content: SingleChildScrollView(child: Text(report.message)),
+      title: Text(report.settings.reportTitle),
+      content: SingleChildScrollView(child: Text(message)),
       actions: [
         OutlinedButton(
             onPressed: () =>

--- a/packages/flutter/utils/astro_error_handling/lib/src/state/models/error_report.dart
+++ b/packages/flutter/utils/astro_error_handling/lib/src/state/models/error_report.dart
@@ -4,7 +4,12 @@ import 'package:astro_types/state_types.dart';
 
 /// Class for carrying basic error information for display to the user.
 class DefaultErrorReport implements ErrorReport, AstroState {
-  const DefaultErrorReport({required this.message, this.trace, this.details});
+  const DefaultErrorReport({
+    required this.message,
+    this.settings = ErrorReportSettings.fullReport,
+    this.trace,
+    this.details,
+  });
 
   @override
   final String message;
@@ -12,19 +17,32 @@ class DefaultErrorReport implements ErrorReport, AstroState {
   final String? trace;
   @override
   final Map<String, String>? details;
+  @override
+  final ErrorReportSettings settings;
 
   @override
-  DefaultErrorReport copyWith({String? message, String? trace}) =>
+  DefaultErrorReport copyWith(
+          {String? message, String? trace, ErrorReportSettings? settings}) =>
       DefaultErrorReport(
-          message: message ?? this.message, trace: trace ?? this.trace);
+        message: message ?? this.message,
+        trace: trace ?? this.trace,
+        settings: settings ?? this.settings,
+      );
 
   @override
-  JsonMap toJson() => <String, dynamic>{'message': message, 'trace': trace};
+  JsonMap toJson() => <String, dynamic>{
+        'message': message,
+        'trace': trace,
+        'settings': settings,
+      };
 
   @override
   bool operator ==(Object other) =>
-      other is ErrorReport && other.message == message && other.trace == trace;
+      other is DefaultErrorReport &&
+      other.message == message &&
+      other.trace == trace &&
+      other.settings == settings;
 
   @override
-  int get hashCode => Object.hash(message, trace);
+  int get hashCode => Object.hash(message, trace, settings);
 }


### PR DESCRIPTION
I added an ErrorReportSettings member to ErrorReport and
DefaultErrorHandlers now requires an ErrorReportSettings parameter
in handleLandingError & handleLaunchError so that an exception can
tell the handlers how it wants to be displayed.

I created AstroException with members for message and reportSettings so
that anyone can easily create an exception that configures the resulting
error message in different ways.

I added AstroInfoException that configures the error message to just
display the message with no stack trace or mission details. This is
intended to be used for things like incorrect (but expected) user input
where we want to give the user info about what happened but not details
like the stack trace that look like a crash.

The CreateErrorReport landing mission now uses the ErrorReportSettings
to configure the message and we also pass the ErrorReportSettings in to
the DefaultErrorReport so the ErrorReportScreen can decide what to
display (eg. how to display title & stack trace).