### PR TITLE
fix(agn): added check for single field case

### DIFF
--- a/packages/flutter/utils/astro_generators/lib/src/subclass_generator.dart
+++ b/packages/flutter/utils/astro_generators/lib/src/subclass_generator.dart
@@ -82,6 +82,12 @@ void generateToString(ModelVisitor visitor, StringBuffer classBuffer) {
 }
 
 void generateHashCode(ModelVisitor visitor, StringBuffer classBuffer) {
+  if (visitor.fields.keys.length == 1) {
+    final String field = visitor.fields.keys.first;
+    classBuffer.writeln('@override\nint get hashCode => $field.hashCode;\n');
+    return;
+  }
+
   classBuffer.writeln('@override\nint get hashCode => Object.hash(');
 
   for (final fieldName in visitor.fields.keys) {


### PR DESCRIPTION
When we have only a single field we can't use Object.hash so we just use
field.hashCode