### PR TITLE
chore(ftl): Add TensorFlowLiteC dependency to iOS podspec

### DIFF
--- a/packages/flutter/plugins/flutter_tflite_ffi/ios/flutter_tflite_ffi.podspec
+++ b/packages/flutter/plugins/flutter_tflite_ffi/ios/flutter_tflite_ffi.podspec
@@ -20,6 +20,8 @@ A new Flutter FFI plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
+  s.static_framework = true
+  s.dependency 'TensorFlowLiteC'
   s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/packages/flutter/plugins/flutter_tflite_ffi/lib/flutter_tflite_ffi.dart
+++ b/packages/flutter/plugins/flutter_tflite_ffi/lib/flutter_tflite_ffi.dart
@@ -11,7 +11,7 @@ String version() => _bindings.TfLiteVersion().cast<Utf8>().toDartString();
 
 final DynamicLibrary _dylib = () {
   if (Platform.isMacOS || Platform.isIOS) {
-    return DynamicLibrary.open(_libName);
+    return DynamicLibrary.process();
   }
   if (Platform.isAndroid || Platform.isLinux) {
     return DynamicLibrary.open('$_libName.so');


### PR DESCRIPTION
This adds the pod to the build. I had to change the podspec to use
static frameworks and change DynamicLibrary.open to
DynamicLibrary.process, as TensorFlowLiteC presumably uses static libs
and these changes make the build and DynamicLibrary access work.