### PR TITLE
chore(acu): Improve error reporting with extra info

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ If you plan to work on several packages at once you will need to open the `monor
 Three letter acronyms used in commit messages:
 
 - aau = astro_auth
-- acf - authorization code flow
+- acf = authorization code flow
+- acu = api_client_utils
 - aeh = astro_error_handling
 - aei = astro_error_handling_interface
 - agn = astro_generators
@@ -89,6 +90,7 @@ Three letter acronyms used in commit messages:
 - jst = json_types
 - lcr = locator
 - mgc = magicians
+- noc = notion_api_client
 - oap = openapi_parser
 - oml = our_meals
 - pae = process_articles_in_emails

--- a/packages/dart/api-clients/api_client_utils/lib/http_status_codes.dart
+++ b/packages/dart/api-clients/api_client_utils/lib/http_status_codes.dart
@@ -1,0 +1,24 @@
+const String httpStatusMessageSource =
+    'https://www.rfc-editor.org/rfc/rfc9110.html';
+const Map<int, String> messageFor = {
+  400:
+      'The 400 (Bad Request) status code indicates that the server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).',
+  401:
+      'The 401 (Unauthorized) status code indicates that the request has not been applied because it lacks valid authentication credentials for the target resource.',
+  403:
+      'The 403 (Forbidden) status code indicates that the server understood the request but refuses to fulfill it.',
+  404:
+      'The 404 (Not Found) status code indicates that the origin server did not find a current representation for the target resource or is not willing to disclose that one exists.',
+  405:
+      'The 405 (Method Not Allowed) status code indicates that the method received in the request-line is known by the origin server but not supported by the target resource.',
+  406:
+      'The 406 (Not Acceptable) status code indicates that the target resource does not have a current representation that would be acceptable to the user agent, according to the proactive negotiation header fields received in the request, and the server is unwilling to supply a default representation.',
+  407:
+      'The 407 (Proxy Authentication Required) status code is similar to 401 (Unauthorized), but it indicates that the client needs to authenticate itself in order to use a proxy for this request.',
+  408:
+      'The 408 (Request Timeout) status code indicates that the server did not receive a complete request message within the time that it was prepared to wait.',
+  409:
+      'The 409 (Conflict) status code indicates that the request could not be completed due to a conflict with the current state of the target resource.',
+  410:
+      'The 410 (Gone) status code indicates that access to the target resource is no longer available at the origin server and that this condition is likely to be permanent.',
+};

--- a/packages/dart/api-clients/api_client_utils/pubspec.yaml
+++ b/packages/dart/api-clients/api_client_utils/pubspec.yaml
@@ -1,14 +1,14 @@
 name: api_client_utils
 description: Classes for use in API Clients.
-version: 0.0.1
+version: 0.0.0-a1
 
 environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  http: ^0.13.4
-  http_parser: ^4.0.1
+  http: ^0.13.5
+  http_parser: ^4.0.2
 
 dev_dependencies:
-  lints: ^2.0.0
-  test: ^1.16.0
+  lints: ^2.0.1
+  test: ^1.24.0


### PR DESCRIPTION
I added some standard explanation of 'error' http status codes.

I moved parsing the response body to before validation so that a non-200
response can access the json for more details.